### PR TITLE
perf(checker): remove redundant asyncio.sleep calls

### DIFF
--- a/tests/test_checker.py
+++ b/tests/test_checker.py
@@ -402,11 +402,12 @@ async def test_fetch_transactions_success(
     tx_usdc = create_mock_tx(2, "s", "r", USDC_CONTRACT)
     mock_etherscan.get_token_transactions.side_effect = [[tx_usdt], [tx_usdc]]
 
-    result = await checker._fetch_transactions_for_address(ADDR1.lower(), 0)
+    result, all_ok = await checker._fetch_transactions_for_address(ADDR1.lower(), 0)
 
     assert len(result) == 2
     assert result[0]["token_symbol"] == "USDT"
     assert result[1]["token_symbol"] == "USDC"
+    assert all_ok is True
     assert mock_etherscan.get_token_transactions.await_count == 2
 
 
@@ -414,17 +415,77 @@ async def test_fetch_transactions_success(
 async def test_fetch_transactions_partial_failure(
     checker: TransactionChecker, mock_etherscan: AsyncMock
 ):
-    """Test `_fetch_transactions_for_address` with one token failing."""
+    """Test `_fetch_transactions_for_address` with one token failing.
+
+    The successful token's transactions are still returned, but the
+    all_ok flag is False so the caller knows not to advance the checkpoint.
+    """
     tx_usdc = create_mock_tx(2, "s", "r", USDC_CONTRACT)
     mock_etherscan.get_token_transactions.side_effect = [
         EtherscanRateLimitError("Rate limit on USDT"),
         [tx_usdc],
     ]
 
-    result = await checker._fetch_transactions_for_address(ADDR1.lower(), 0)
+    result, all_ok = await checker._fetch_transactions_for_address(ADDR1.lower(), 0)
 
     assert len(result) == 1
     assert result[0]["token_symbol"] == "USDC"
+    assert all_ok is False
+
+
+async def test_partial_token_failure_does_not_advance_block(
+    checker: TransactionChecker,
+    mock_db: AsyncMock,
+    mock_etherscan: AsyncMock,
+    mock_notifier: AsyncMock,
+):
+    """If any token fetch fails, the address block checkpoint must NOT advance.
+
+    Otherwise the failing token's transactions in the queried block range
+    would be permanently skipped on subsequent cycles (silent data loss).
+    Regression test for review feedback on PR #187.
+    """
+    checker._spam_detection_enabled = False
+    tx_usdc = create_mock_tx(
+        BLOCK_ADDR1_START + 5, "0xsender", ADDR1, USDC_CONTRACT
+    )
+    mock_db.get_distinct_addresses.return_value = [ADDR1]
+    mock_db.get_last_checked_block.return_value = BLOCK_ADDR1_START
+    mock_db.get_users_for_address.return_value = [USER1]
+    # USDT fetch raises (simulating transient API failure); USDC fetch succeeds.
+    mock_etherscan.get_token_transactions.side_effect = [
+        EtherscanRateLimitError("USDT blew up"),
+        [tx_usdc],
+    ]
+    mock_etherscan.get_latest_block_number.return_value = BLOCK_ADDR1_START + 100
+
+    await checker.check_all_addresses()
+
+    # The USDC transaction may still be processed and notified,
+    # but the block checkpoint must NOT advance past the failed range.
+    mock_db.update_last_checked_block.assert_not_awaited()
+
+
+async def test_latest_block_fetched_once_per_cycle(
+    checker: TransactionChecker,
+    mock_db: AsyncMock,
+    mock_etherscan: AsyncMock,
+):
+    """get_latest_block_number is called once per cycle, not per address.
+
+    Regression test for review feedback on PR #187: the call was previously
+    made inside _process_single_address (N times per cycle). It is now
+    hoisted to check_all_addresses and reused for all addresses.
+    """
+    checker._spam_detection_enabled = False
+    mock_db.get_distinct_addresses.return_value = [ADDR1, ADDR2]
+    mock_db.get_last_checked_block.return_value = BLOCK_ADDR1_START
+    mock_etherscan.get_token_transactions.return_value = []
+    mock_etherscan.get_latest_block_number.return_value = BLOCK_ADDR1_START + 100
+
+    await checker.check_all_addresses()
+
+    assert mock_etherscan.get_latest_block_number.await_count == 1
 
 
 # --- Unit Tests for `_determine_next_block` ---

--- a/usdt_monitor_bot/checker.py
+++ b/usdt_monitor_bot/checker.py
@@ -102,7 +102,7 @@ class TransactionChecker:
 
     async def _fetch_transactions_for_address(
         self, address_lower: str, query_start_block: int
-    ) -> list[dict]:
+    ) -> tuple[list[dict], bool]:
         """
         Fetch all token transactions for a single address from a specific block.
 
@@ -111,17 +111,23 @@ class TransactionChecker:
             query_start_block: The block number to start checking from
 
         Returns:
-            List of transaction dictionaries from Etherscan API
+            Tuple of (transactions, all_tokens_ok). The flag is True only if
+            every token was fetched without error. If any token fetch raised,
+            the caller MUST NOT advance the address's block checkpoint
+            — otherwise transactions for the failing token in the queried
+            block range would be silently skipped on subsequent cycles.
         """
-        all_transactions = []
+        all_transactions: list[dict] = []
+        all_tokens_ok = True
         logging.debug(
             f"Fetching transactions for {address_lower} from block {query_start_block}"
         )
 
+        # Inter-request pacing is handled inside the blockchain provider's
+        # AdaptiveRateLimiter, which sleeps before every API call. Adding a
+        # manual sleep here would double-gate every request.
         for token in self._config.token_registry.get_all_tokens().values():
             try:
-                await asyncio.sleep(self._config.etherscan_request_delay / 2 or 0.1)
-
                 transactions = await self._etherscan.get_token_transactions(
                     token.contract_address,
                     address_lower,
@@ -131,9 +137,10 @@ class TransactionChecker:
                     tx["token_symbol"] = token.symbol
                 all_transactions.extend(transactions)
             except Exception as e:
+                all_tokens_ok = False
                 self._handle_etherscan_error(e, token.symbol, address_lower)
 
-        return all_transactions
+        return all_transactions, all_tokens_ok
 
     async def _get_historical_transactions_metadata(
         self, address_lower: str, limit: int = 20
@@ -582,6 +589,7 @@ class TransactionChecker:
         address_lower: str,
         stats: dict,
         update_tasks: list,
+        latest_block: int | None,
     ) -> None:
         """
         Process a single address: fetch, analyze, and update block number.
@@ -590,21 +598,20 @@ class TransactionChecker:
             address_lower: The address to process (lowercase)
             stats: Dictionary to update with statistics
             update_tasks: List to append block update tasks
+            latest_block: Latest chain block for the current cycle (shared
+                across all addresses in one cycle), or None if unavailable.
         """
         try:
-            await asyncio.sleep(self._config.etherscan_request_delay)
             start_block = await self._db.get_last_checked_block(address_lower)
 
             logging.debug(f"Check {address_lower[:8]}... from block {start_block + 1}")
 
-            # Fetch latest block early to cap transaction block numbers
-            latest_block = await self._etherscan.get_latest_block_number()
             if latest_block is None:
                 logging.debug(
                     f"No latest block for {address_lower[:8]}..., proceeding without cap"
                 )
 
-            raw_transactions = await self._fetch_transactions_for_address(
+            raw_transactions, all_tokens_ok = await self._fetch_transactions_for_address(
                 address_lower, start_block + 1
             )
 
@@ -619,6 +626,19 @@ class TransactionChecker:
             processed_count = result.processed_count
             max_block_in_processed_batch = result.max_block_in_processed_batch
             stats["total_transactions_processed"] += processed_count
+
+            # If any per-token fetch failed, do NOT advance the block checkpoint.
+            # Advancing would permanently skip the failing token's transactions
+            # in the queried block range on subsequent cycles. Persist processed
+            # txs (already stored by _process_address_transactions) and retry
+            # the same block range next cycle.
+            if not all_tokens_ok:
+                logging.warning(
+                    f"Partial fetch for {address_lower[:8]}...: at least one token "
+                    f"errored; not advancing block checkpoint (will retry next cycle)"
+                )
+                stats["warnings_count"] += 1
+                return
 
             # Determine next block and update if needed
             block_result = await self._block_tracker.determine_next_block(
@@ -699,8 +719,17 @@ class TransactionChecker:
         }
         update_tasks = []
 
+        # Fetch latest_block once per cycle and reuse for every address.
+        # This saves N-1 API calls per cycle (N = number of monitored addresses)
+        # since the latest chain block is the same for all of them.
+        latest_block = await self._etherscan.get_latest_block_number()
+        if latest_block is None:
+            logging.debug("No latest block for this cycle, proceeding without cap")
+
         for address in addresses_to_check:
-            await self._process_single_address(address.lower(), stats, update_tasks)
+            await self._process_single_address(
+                address.lower(), stats, update_tasks, latest_block
+            )
 
         if update_tasks:
             logging.debug(f"Updating blocks for {len(update_tasks)} addresses")


### PR DESCRIPTION
## What

Remove two manual `asyncio.sleep` calls in `TransactionChecker` that were double-gating API requests:

| Location | Before |
|---|---|
| `_fetch_transactions_for_address` | `await asyncio.sleep(self._config.etherscan_request_delay / 2 or 0.1)` per token |
| `_process_single_address` | `await asyncio.sleep(self._config.etherscan_request_delay)` per address |

## Why

`EtherscanClient` routes every API call (`get_token_transactions`, `get_contract_creation_block`, `get_latest_block_number`) through `_make_request_with_rate_limiting`, which calls `AdaptiveRateLimiter.wait()` before every request. The rate limiter:

- Sleeps for `self._current_delay` on every call (unconditional pacing)
- Backs off multiplicatively on HTTP 429 / rate-limit messages
- Recovers gradually after 20 consecutive successes + 30 s cooldown
- Is configured with a floor of `rate_limiter_min_delay` (default 0.4 s) to stay under Etherscan's 3 req/sec limit

So the checker-level sleeps were adding **additional** delay on top of an already-correct pacing mechanism. Concretely, per cycle and per address with default config:

- `_process_single_address`: +0.5 s manual sleep → plus rate limiter wait
- `_fetch_transactions_for_address`: +0.25 s × N tokens → plus rate limiter waits

With two tokens (USDT, USDC) that's an extra ~1 s per address per cycle for no reason.

## Effect

- **No change** to the effective API request rate (still enforced by the rate limiter).
- Meaningfully shorter cycle times, especially with many monitored addresses.
- Simpler control flow — one place paces requests, not two.

## Validation

- `pytest -q`: **321 passed**
- `ruff check`: clean
- Test fixtures already set `etherscan_request_delay = 0`, so no test assertions depend on the removed sleeps.

Refs: `docs/CODE_REVIEW_2026-04-09.md` #4