### PR TITLE
perf(checker): batch pre-fetch spam-detection enrichment data

### DIFF
--- a/docs/features/batch-spam-enrichment.md
+++ b/docs/features/batch-spam-enrichment.md
@@ -1,0 +1,322 @@
+# Feature: Batch Pre-fetch for Spam Detection Enrichment
+
+**Status:** ✅ Implemented
+**Area:** `checker.py`, `database.py`, `blockchain_provider.py`, `etherscan.py`, `blockscout.py`, `moralis.py`
+**Target files:**
+- `usdt_monitor_bot/checker.py` (`_send_notifications_for_batch`, `_enrich_transaction_metadata`, `_get_contract_age_blocks`)
+- `usdt_monitor_bot/database.py` (new bulk query methods)
+- `usdt_monitor_bot/blockchain_provider.py` + `etherscan.py` / `blockscout.py` / `moralis.py` (new bulk contract-creation method)
+
+---
+
+## 1. Problem
+
+Current per-transaction enrichment in `checker.py::_enrich_transaction_metadata` (lines ~233–269) fires **two remote calls per tx**:
+
+1. `self._db.is_new_sender_address(monitored_address, from_address)` — one SQLite roundtrip (each call dispatched via `asyncio.to_thread` → opens a fresh connection).
+2. `self._get_contract_age_blocks(from_address, block_number)` — on cache miss, one Etherscan `getcontractcreation` call.
+
+Plus, upstream, `_send_notifications_for_batch` already calls `get_recent_transactions` once per address (fine), but the inner loop is strictly sequential:
+
+```python
+for tx in batch:                                # N transactions
+    await self._db.is_new_sender_address(...)   # 1 DB roundtrip
+    await self._etherscan.get_contract_creation_block(...)  # 1 HTTP call on miss
+    await self._db.store_transaction(...)       # 1 DB roundtrip
+```
+
+### Scaling math
+
+At **500 k txs/cycle** (as raised in the issue):
+
+| Call                              | Per tx | Per cycle  | Notes                                               |
+|-----------------------------------|--------|------------|-----------------------------------------------------|
+| `is_new_sender_address`           | 1      | 500 k      | Each = open conn + SELECT                           |
+| `get_contract_creation_block`     | ≤1     | up to 500k | Cached, but cold cache / eviction → Etherscan burst |
+| `store_transaction`               | 1      | 500 k      | Existing; not in scope but same pattern             |
+| **Total extra per-tx roundtrips** |        | **~1.5M**  |                                                     |
+
+Each `is_new_sender_address` call goes through `_run_sync_db_operation` → `asyncio.to_thread` → opens and closes a SQLite connection. That is cheap in absolute terms but dominates wall-clock when multiplied by 500 k, and it serialises the whole spam-detection phase behind the GIL-bounded thread pool.
+
+The Etherscan path is worse: `getcontractcreation` is rate-limited (5 req/s on the free tier) and each miss also passes through the tenacity retry layer. A cold cache on 10 k distinct senders = ~35 minutes just for contract-age lookups.
+
+---
+
+## 2. Goal
+
+Replace the inner per-tx N+1 pattern with **batch pre-fetch**, done once per address (or once per cycle where cheap), so that `_enrich_transaction_metadata` becomes a pure in-memory lookup.
+
+Target after change, per address with `M` unique senders in the batch:
+
+| Call                              | Before | After                          |
+|-----------------------------------|--------|--------------------------------|
+| `is_new_sender_address`           | `N`    | **1** (bulk SELECT IN …)       |
+| `get_contract_creation_block`     | `≤N`   | **⌈M_uncached / 5⌉** (batched) |
+| `get_recent_transactions`         | 1      | 1 (unchanged)                  |
+
+For 500 k txs spread across 10 k senders, that is ~10 k → ~2 k HTTP calls on cold cache, and 500 k → number-of-addresses DB calls.
+
+---
+
+## 3. Non-goals
+
+- **Not** touching `store_transaction` in this feature — it is a write path and the `INSERT OR IGNORE` pattern is already idempotent. A separate follow-up (`executemany`) can batch it later.
+- **Not** changing `SpamDetector.analyze_transaction` itself — it already operates on already-enriched `TransactionMetadata`. The change is upstream.
+- **Not** changing the rest of the filter pipeline (dust / similarity / timing). They already work off the in-memory historical list.
+- **Not** introducing cross-cycle caching of sender-history. Dedup cache stays in-memory, per-process, as today.
+
+---
+
+## 4. Design
+
+### 4.1. Bulk DB method: `get_known_senders`
+
+Add to `DatabaseManager`:
+
+```python
+def _get_known_senders_sync(
+    self, monitored_address: str, sender_addresses: list[str]
+) -> set[str]:
+    """Return the subset of sender_addresses already seen for monitored_address."""
+    if not sender_addresses:
+        return set()
+    # Deduplicate + lowercase in caller; this stays a pure lookup
+    placeholders = ",".join("?" * len(sender_addresses))
+    query = f"""SELECT DISTINCT from_address
+                FROM transaction_history
+                WHERE monitored_address = ?
+                  AND from_address IN ({placeholders})"""
+    params = (monitored_address.lower(), *sender_addresses)
+    rows = self._execute_db_query(query, params, fetch_all=True) or []
+    return {row[0] for row in rows}
+
+async def get_known_senders(
+    self, monitored_address: str, sender_addresses: list[str]
+) -> set[str]:
+    return await self._run_sync_db_operation(
+        self._get_known_senders_sync, monitored_address, sender_addresses
+    )
+```
+
+Notes:
+- Uses a single `IN (?, ?, …)` query. SQLite's parameter cap is 32 766 (SQLITE_MAX_VARIABLE_NUMBER on modern builds) — safely over any realistic per-address batch, but we chunk defensively at **500** per query to stay well below historic 999 cap on older builds.
+- Returned as a `set[str]` of **lowercased** addresses so the caller can compute "new" with `sender not in known`.
+- We already have an index on `transaction_history(monitored_address)`. Verify `(monitored_address, from_address)` composite index exists; if not, add it in the same PR (see §4.5).
+
+### 4.2. Bulk contract-creation method
+
+#### Per-provider batch support (verified against current clients)
+
+| Provider | Endpoint | Batch? | Limit | Notes |
+|---|---|---|---|---|
+| **Etherscan** (`etherscan.py:426`) | `module=contract&action=getcontractcreation&contractaddresses=<csv>` | ✅ native | **5** per call | `contractaddresses` param is already plural; response is already a list (`result[0]` today). Rate limit unchanged (5 req/s free tier), so 1 batched call ≈ 1 single call in budget terms. |
+| **Blockscout** (`blockscout.py:165`) | REST v2 `GET /api/v2/addresses/{address}` | ❌ | 1 | Address is in URL path; no filter-by-list endpoint. `/api/v2/addresses` (plural) returns the global ranked address list, not a lookup. Etherscan-compat `getcontractcreation` on Blockscout was explicitly abandoned for v2 REST in this repo (`CLAUDE.md`). Must loop. |
+| **Moralis** (`moralis.py:162`) | `GET /api/v2.2/{contract_address}?chain=eth` | ❌ on current endpoint | 1 | Moralis does offer `GET /api/v2.2/erc20/metadata?chain=eth&addresses=<a>&addresses=<b>` (up to 25, returns `block_number`) but it's a different endpoint shape and schema. Moralis is fallback #2 (only hit when Etherscan + Blockscout circuits are open), so the traffic is tiny. Out of scope; filed as follow-up in §8. |
+
+#### Protocol change
+
+Extend `BlockchainProvider` protocol in `blockchain_provider.py`:
+
+```python
+async def get_contract_creation_blocks(
+    self, contract_addresses: list[str]
+) -> dict[str, int | None]:
+    """
+    Batch variant. Returns a mapping from lowercased address to creation block,
+    or None if the address is not a contract / lookup failed for that entry.
+    Missing keys in the return value are treated as None.
+    """
+```
+
+- **Default implementation** on the protocol (or as a mixin) simply loops `get_contract_creation_block` for each address. This is what `BlockscoutClient` and `MoralisClient` will inherit unchanged — no client rewrite required.
+- **`EtherscanClient` override** chunks into groups of 5, issues one request per chunk, parses the full `result` array, and maps each entry back by `contractAddress` (lowercased). Addresses absent from the response are mapped to `None`.
+- **`WithFallback.get_contract_creation_blocks`**:
+  - Call primary's batch method.
+  - If the **whole call raises** a transport-level error (or the circuit is open), fall back to the next provider for the full address list — same policy as the existing single-item fallback.
+  - If the primary returns normally but some addresses map to `None`, **treat those as authoritative** ("not a contract" is a valid answer) — do **not** re-query fallbacks, because Blockscout/Moralis loop per-address and would re-amplify the N+1 we are trying to kill.
+  - Per-chunk Etherscan failure inside the batch method → the Etherscan override degrades that specific chunk to single-address calls, so one bad address in a chunk cannot black-hole the other four.
+
+### 4.3. Checker changes
+
+Rewrite `_send_notifications_for_batch` so it pre-fetches enrichment data once, before entering the loop:
+
+```python
+async def _send_notifications_for_batch(self, user_ids, batch, address_lower):
+    historical_metadata = await self._get_historical_transactions_metadata(
+        address_lower, limit=20
+    )
+
+    # --- Batch pre-fetch phase ---
+    unique_senders = list({
+        (tx.get("from") or "").lower()
+        for tx in batch
+        if tx.get("from")
+    })
+
+    known_senders = await self._db.get_known_senders(address_lower, unique_senders)
+
+    # Only fetch contract ages for senders not already in the cache
+    uncached_senders = [
+        s for s in unique_senders if s not in self._contract_creation_cache
+    ]
+    if uncached_senders:
+        creation_blocks = await self._etherscan.get_contract_creation_blocks(
+            uncached_senders
+        )
+        for addr, block in creation_blocks.items():
+            self._cache_contract_block(addr, block)
+        # Also cache explicit misses so we don't re-query next cycle
+        for addr in uncached_senders:
+            if addr not in creation_blocks:
+                self._cache_contract_block(addr, None)
+
+    # --- Per-tx processing now uses pre-fetched data ---
+    enrichment_ctx = EnrichmentContext(
+        known_senders=known_senders,
+        # contract ages read straight from self._contract_creation_cache
+    )
+
+    notifications_sent = 0
+    for tx in batch:
+        try:
+            notifications_sent += await self._process_single_transaction(
+                tx, user_ids, address_lower, historical_metadata, enrichment_ctx
+            )
+        except Exception as e:
+            logging.error(
+                f"Process tx error {tx.get('hash', 'N/A')[:16]}: {e}", exc_info=True
+            )
+```
+
+New dataclass (module-level in `checker.py`):
+
+```python
+@dataclass
+class EnrichmentContext:
+    """Pre-fetched enrichment data shared across a batch of txs for one address."""
+    known_senders: set[str]
+```
+
+Refactor `_enrich_transaction_metadata` to take the context and become non-awaiting except for the rare on-demand fallback:
+
+```python
+async def _enrich_transaction_metadata(
+    self,
+    tx_metadata: TransactionMetadata,
+    address_lower: str,
+    historical_metadata: list[TransactionMetadata],
+    ctx: EnrichmentContext,
+) -> RiskAnalysis:
+    sender = tx_metadata.from_address.lower()
+    tx_metadata.is_new_address = sender not in ctx.known_senders
+
+    # Contract age: always read from cache (populated by batch pre-fetch).
+    # On cache miss (shouldn't happen if pre-fetch ran), fall back to the old
+    # single-address path so we never regress.
+    cached = self._contract_creation_cache.get(sender)
+    if cached is None and sender not in self._contract_creation_cache:
+        contract_age = await self._get_contract_age_blocks(
+            sender, tx_metadata.block_number
+        )
+    else:
+        contract_age = (
+            max(0, tx_metadata.block_number - cached) if cached is not None else 0
+        )
+    tx_metadata.contract_age_blocks = contract_age
+
+    # ... whitelist + analyze_transaction unchanged
+```
+
+Key invariant: once a tx is classified as "new sender" within a batch, subsequent txs from the **same** sender in the same batch should be classified as "not new" (since the first one has now been observed). Handle this by mutating `ctx.known_senders.add(sender)` inside the loop after processing each tx. This matches the pre-change behaviour where `store_transaction` ran between loop iterations and would have made `is_new_sender_address` return `False` on the next check — **actually verify this**: today's code awaits `store_transaction` inside `_process_single_transaction` before the next iteration, so the DB state flips mid-loop. The new code must preserve that semantic.
+
+### 4.4. Cache interaction
+
+`_contract_creation_cache` is still the source of truth for contract ages. The batch pre-fetch simply *populates* it in bulk, then per-tx enrichment reads from it. The bounded-eviction logic in `_cache_contract_block` stays as-is.
+
+One subtlety: if `contract_creation_cache_size` is smaller than the number of unique senders in a single batch, we could evict our own pre-fetched data mid-loop. Mitigation: during pre-fetch, detect this and either (a) log a warning and fall back to the old single-address path, or (b) use a short-lived per-batch dict overlay. Recommended: **(a)**, because hitting that limit is a config-smell worth surfacing, and the fallback behaviour is simply "same as before this feature".
+
+### 4.5. Index check
+
+`transaction_history` should already have an index supporting the new `IN` query. Confirm in `database.py` schema and add if missing:
+
+```sql
+CREATE INDEX IF NOT EXISTS idx_tx_history_monitored_from
+    ON transaction_history(monitored_address, from_address);
+```
+
+This benefits both `is_new_sender_address` (existing, if kept for fallback) and the new `get_known_senders`.
+
+---
+
+## 5. Step-by-step implementation
+
+1. **Schema/index check** (`database.py`):
+   - Audit `_init_db` for `transaction_history` indexes.
+   - Add `idx_tx_history_monitored_from` if not present.
+
+2. **Add bulk DB method** (`database.py`):
+   - `_get_known_senders_sync` + `get_known_senders` as in §4.1.
+   - Chunking at 500 params per query.
+   - Unit test: empty input → empty set; mix of known/unknown → exact subset; case-insensitive match.
+
+3. **Extend provider protocol** (`blockchain_provider.py`):
+   - Add `get_contract_creation_blocks(addresses) -> dict[str, int | None]` to the `BlockchainProvider` protocol with a default implementation that loops `get_contract_creation_block` (keeps Moralis/Blockscout working unchanged).
+   - Add batch method to `WithFallback` — dispatches to primary, falls back per-provider on transport error only.
+
+4. **Implement batch Etherscan call** (`etherscan.py`):
+   - New `get_contract_creation_blocks` that chunks the input into groups of 5, issues one `getcontractcreation` request per chunk, and merges results into a `dict`.
+   - Reuse `_make_request_with_rate_limiting`.
+   - Same tenacity retry decorator as the single-address version.
+   - On per-chunk failure, fall back to single-address calls for that chunk so we degrade gracefully (so a single bad address in a chunk does not black-hole the others).
+
+5. **Refactor checker** (`checker.py`):
+   - Add `EnrichmentContext` dataclass.
+   - Rewrite `_send_notifications_for_batch` to do the batch pre-fetch as in §4.3.
+   - Update `_enrich_transaction_metadata` + `_process_single_transaction` signatures to thread `ctx` through.
+   - Preserve the "same-sender-appears-twice-in-batch" semantic by `ctx.known_senders.add(sender)` after each tx.
+   - Leave `_get_contract_age_blocks` intact as a fallback path.
+
+6. **Tests** (`tests/test_checker.py`, `tests/test_database.py`, `tests/test_etherscan.py`):
+   - `test_get_known_senders_returns_intersection` — seed history, assert only known addresses returned.
+   - `test_get_known_senders_empty_input` — no DB hit, returns `set()`.
+   - `test_batch_contract_creation_chunks_by_5` — mock HTTP layer, assert 12 addresses → 3 chunked requests.
+   - `test_batch_contract_creation_falls_back_on_chunk_error` — one chunk raises; verify per-address fallback.
+   - `test_enrichment_uses_batch_prefetch` — spy on `is_new_sender_address` and `get_contract_creation_block` single-address methods; assert **zero calls** when batch methods return data for every sender.
+   - `test_same_sender_twice_in_batch_second_is_not_new` — assert semantic parity with pre-change behaviour.
+   - `test_enrichment_falls_back_when_cache_too_small` — set `contract_creation_cache_size=1`, feed batch with 5 distinct senders, assert the old single-address path is still used and results match.
+   - `test_enrichment_cold_cache_1000_txs` (benchmark-style, not CI-gated): with a mocked provider, assert the number of HTTP calls is ≤ `ceil(unique_senders/5)` and DB calls ≤ `1 + ceil(unique_senders/500)`.
+
+7. **Docs** — update `CLAUDE.md` "Key design decisions" with a bullet on batch pre-fetch, and reference this plan.
+
+---
+
+## 6. Risks & mitigations
+
+| Risk | Mitigation |
+|---|---|
+| Semantic drift for repeated senders in one batch | Mutate `ctx.known_senders` after each tx (see §4.3 invariant); add explicit test. |
+| Batch contract-creation endpoint returns partial results (some addresses missing) | Treat missing-in-response as `None` and cache as such. Confirmed by per-chunk-fallback step 4. |
+| Etherscan chunk-level failure poisons 5 addresses at once | Per-chunk fallback to single-address calls on error (§4.4 step 4). |
+| `_contract_creation_cache` too small vs batch size | Detect and fall back to old path; log warning pointing at `contract_creation_cache_size`. |
+| Fallback providers (Blockscout, Moralis) lack batch support | Default protocol impl loops; no change required to those clients. |
+| Large `IN (?, ?, …)` blows SQLite parameter limit | Chunk at 500 per query in `get_known_senders`. |
+| Index migration on existing prod DB adds load | `CREATE INDEX IF NOT EXISTS` is idempotent and fast on `transaction_history`. Run during normal startup. |
+
+---
+
+## 7. Success criteria
+
+- At 10 k unique senders / 500 k txs / cycle (simulated in a benchmark test), the number of DB roundtrips for `is_new_sender_address` drops from ~500 k to ≤ 20, and the number of Etherscan `getcontractcreation` calls drops from ≤ 10 k to ≤ 2 000 on cold cache.
+- No behavioural regression in existing spam-detection tests.
+- `ruff check` clean, `pytest` green.
+- Cycle wall-clock time for the existing prod workload measurably lower (capture before/after in PR description).
+
+---
+
+## 8. Out-of-scope follow-ups (noted, not done here)
+
+- Batched `store_transaction` via `executemany`.
+- Persistent (on-disk) contract-creation cache survival across restarts.
+- Cross-address sharing of `known_senders` pre-fetch when many monitored addresses share the same senders (unlikely in practice).
+- Moving `get_recent_transactions` into the same pre-fetch phase for multiple addresses at once.
+- **Moralis bulk contract-creation**: migrate `MoralisClient.get_contract_creation_block` from the per-address `GET /api/v2.2/{address}` endpoint to the bulk `GET /api/v2.2/erc20/metadata?chain=eth&addresses=...` endpoint (up to 25 per call). Only worth doing if Moralis ever becomes the hot path (i.e. Etherscan + Blockscout circuits open for sustained periods).

--- a/tests/test_blockscout.py
+++ b/tests/test_blockscout.py
@@ -211,6 +211,63 @@ async def test_get_contract_creation_block_non_200(mock_config):
     assert result is None
 
 
+# --- get_contract_creation_blocks (bulk loops single-address) ---
+
+
+async def test_get_contract_creation_blocks_loops_single_address(mock_config):
+    """Blockscout has no native batch endpoint; the bulk method must loop.
+
+    Verifies that ``get_contract_creation_blocks`` invokes the single-address
+    method once per input and merges the results into a dict keyed by
+    lowercased address.
+    """
+    addrs = [
+        "0xAa" + "0" * 38,
+        "0xBb" + "0" * 38,
+        "0xCc" + "0" * 38,
+    ]
+    client = BlockscoutClient(mock_config)
+    # Patch the single-address method so the test does not depend on HTTP.
+    client.get_contract_creation_block = AsyncMock(
+        side_effect=[100, None, 300]
+    )
+
+    result = await client.get_contract_creation_blocks(addrs)
+    assert result == {
+        addrs[0].lower(): 100,
+        addrs[1].lower(): None,
+        addrs[2].lower(): 300,
+    }
+    assert client.get_contract_creation_block.await_count == 3
+
+
+async def test_get_contract_creation_blocks_deduplicates(mock_config):
+    """Duplicate addresses in the input should only be fetched once."""
+    addr = "0xabcabcabcabcabcabcabcabcabcabcabcabcabca"
+    client = BlockscoutClient(mock_config)
+    client.get_contract_creation_block = AsyncMock(return_value=42)
+
+    result = await client.get_contract_creation_blocks(
+        [addr, addr.upper(), addr]
+    )
+    assert result == {addr: 42}
+    assert client.get_contract_creation_block.await_count == 1
+
+
+async def test_get_contract_creation_blocks_swallows_per_address_errors(
+    mock_config,
+):
+    """Errors from individual lookups are swallowed and recorded as None."""
+    addrs = ["0x" + "a" * 40, "0x" + "b" * 40]
+    client = BlockscoutClient(mock_config)
+    client.get_contract_creation_block = AsyncMock(
+        side_effect=[aiohttp.ClientError("down"), 7]
+    )
+
+    result = await client.get_contract_creation_blocks(addrs)
+    assert result == {addrs[0]: None, addrs[1]: 7}
+
+
 # --- API key handling ---
 
 

--- a/tests/test_checker.py
+++ b/tests/test_checker.py
@@ -1050,3 +1050,334 @@ async def test_process_unknown_token_returns_zero(
     assert result == 0
     mock_notifier.send_token_notification.assert_not_awaited()
     mock_db.store_transaction.assert_not_awaited()
+
+
+# --- Batch spam-enrichment pre-fetch tests ---
+
+
+async def test_prefetch_eliminates_per_tx_sender_and_contract_calls(
+    checker: TransactionChecker,
+    mock_db: AsyncMock,
+    mock_etherscan: AsyncMock,
+    mock_notifier: AsyncMock,
+):
+    """
+    End-to-end check: for a batch of N txs from M unique senders,
+    the checker makes exactly 1 bulk DB call and 1 bulk contract-creation call,
+    and **zero** single-address fallback calls.
+    """
+    mock_db.get_recent_transactions.return_value = []
+    mock_db.get_users_for_address.return_value = [USER1]
+    # Batch mode is controlled by the presence of the bulk methods; make them
+    # return deterministic data so we can assert over the per-tx path.
+    mock_db.get_known_senders.return_value = set()
+    mock_etherscan.get_contract_creation_blocks.return_value = {
+        "0xsender0000000000000000000000000000000001": 100,
+        "0xsender0000000000000000000000000000000002": 200,
+        "0xsender0000000000000000000000000000000003": 300,
+    }
+
+    senders = [
+        "0xsender0000000000000000000000000000000001",
+        "0xsender0000000000000000000000000000000002",
+        "0xsender0000000000000000000000000000000003",
+    ]
+    batch = []
+    for i, sender in enumerate(senders):
+        tx = create_mock_tx(
+            BLOCK_ADDR1_START + 1 + i,
+            sender,
+            ADDR1,
+            USDT_CONTRACT,
+            tx_hash=f"0xbatch{i:04d}",
+        )
+        tx["token_symbol"] = "USDT"
+        batch.append(tx)
+
+    await checker._send_notifications_for_batch(
+        [USER1], batch, ADDR1.lower()
+    )
+
+    # Exactly one bulk DB call for known senders
+    mock_db.get_known_senders.assert_awaited_once()
+    bulk_args = mock_db.get_known_senders.await_args
+    assert bulk_args.args[0] == ADDR1.lower()
+    assert set(bulk_args.args[1]) == set(senders)
+
+    # Exactly one bulk contract-creation call
+    mock_etherscan.get_contract_creation_blocks.assert_awaited_once()
+    creation_args = mock_etherscan.get_contract_creation_blocks.await_args
+    assert set(creation_args.args[0]) == set(senders)
+
+    # Per-tx fallback paths must NOT have been hit
+    mock_db.is_new_sender_address.assert_not_awaited()
+    mock_etherscan.get_contract_creation_block.assert_not_awaited()
+
+    # And a notification was sent for each tx
+    assert mock_notifier.send_token_notification.await_count == 3
+
+
+async def test_prefetch_marks_all_senders_known_as_not_new(
+    checker: TransactionChecker,
+    mock_db: AsyncMock,
+    mock_etherscan: AsyncMock,
+    mock_notifier: AsyncMock,
+):
+    """When every sender is already known, none of the txs should be flagged as new."""
+    mock_db.get_recent_transactions.return_value = []
+    mock_db.get_users_for_address.return_value = [USER1]
+    # Disable contract-age lookup noise by returning all None.
+    mock_etherscan.get_contract_creation_blocks.return_value = {}
+
+    sender = "0xsender0000000000000000000000000000000099"
+    # Bulk DB reports the sender as known.
+    mock_db.get_known_senders.return_value = {sender}
+
+    tx = create_mock_tx(
+        BLOCK_ADDR1_START + 1, sender, ADDR1, USDT_CONTRACT, tx_hash="0xknown01"
+    )
+    tx["token_symbol"] = "USDT"
+
+    # Spy on analyze_transaction to inspect the enriched metadata it receives.
+    captured = {}
+    real_analyze = checker._spam_detector.analyze_transaction
+
+    def _capture(metadata, *args, **kwargs):
+        captured["is_new_address"] = metadata.is_new_address
+        return real_analyze(metadata, *args, **kwargs)
+
+    checker._spam_detector.analyze_transaction = _capture  # type: ignore[method-assign]
+
+    await checker._send_notifications_for_batch(
+        [USER1], [tx], ADDR1.lower()
+    )
+
+    assert captured["is_new_address"] is False
+    mock_db.is_new_sender_address.assert_not_awaited()
+
+
+async def test_prefetch_same_sender_twice_second_is_not_new(
+    checker: TransactionChecker,
+    mock_db: AsyncMock,
+    mock_etherscan: AsyncMock,
+):
+    """
+    If the same sender appears twice in a batch, the first tx should see it as
+    new and the second as known — matching pre-batching semantics, where
+    store_transaction() mid-loop would flip the DB state between iterations.
+    """
+    mock_db.get_recent_transactions.return_value = []
+    mock_db.get_users_for_address.return_value = [USER1]
+    mock_db.get_known_senders.return_value = set()
+    mock_etherscan.get_contract_creation_blocks.return_value = {}
+
+    sender = "0xsender00000000000000000000000000000000ab"
+    tx1 = create_mock_tx(
+        BLOCK_ADDR1_START + 1, sender, ADDR1, USDT_CONTRACT, tx_hash="0xdup01"
+    )
+    tx1["token_symbol"] = "USDT"
+    tx2 = create_mock_tx(
+        BLOCK_ADDR1_START + 2, sender, ADDR1, USDC_CONTRACT, tx_hash="0xdup02"
+    )
+    tx2["token_symbol"] = "USDC"
+
+    # Spy on analyze_transaction to capture is_new_address per call.
+    observed: list[bool] = []
+    real_analyze = checker._spam_detector.analyze_transaction
+
+    def _capture(metadata, *args, **kwargs):
+        observed.append(metadata.is_new_address)
+        return real_analyze(metadata, *args, **kwargs)
+
+    checker._spam_detector.analyze_transaction = _capture  # type: ignore[method-assign]
+
+    await checker._send_notifications_for_batch(
+        [USER1], [tx1, tx2], ADDR1.lower()
+    )
+
+    assert observed == [True, False]
+
+
+async def test_prefetch_populates_contract_creation_cache(
+    checker: TransactionChecker,
+    mock_db: AsyncMock,
+    mock_etherscan: AsyncMock,
+):
+    """Bulk pre-fetch populates _contract_creation_cache with both hits and misses."""
+    mock_db.get_recent_transactions.return_value = []
+    mock_db.get_users_for_address.return_value = [USER1]
+    mock_db.get_known_senders.return_value = set()
+
+    hit_sender = "0xsender0000000000000000000000000000000501"
+    miss_sender = "0xsender0000000000000000000000000000000502"
+    mock_etherscan.get_contract_creation_blocks.return_value = {
+        hit_sender: 12345,
+        # miss_sender intentionally absent; checker should cache it as None.
+    }
+
+    tx1 = create_mock_tx(
+        BLOCK_ADDR1_START + 1, hit_sender, ADDR1, USDT_CONTRACT, tx_hash="0xcache01"
+    )
+    tx1["token_symbol"] = "USDT"
+    tx2 = create_mock_tx(
+        BLOCK_ADDR1_START + 2, miss_sender, ADDR1, USDT_CONTRACT, tx_hash="0xcache02"
+    )
+    tx2["token_symbol"] = "USDT"
+
+    await checker._send_notifications_for_batch(
+        [USER1], [tx1, tx2], ADDR1.lower()
+    )
+
+    assert checker._contract_creation_cache[hit_sender] == 12345
+    assert checker._contract_creation_cache[miss_sender] is None
+
+    # Single-address fallback must not have been invoked at any point.
+    mock_etherscan.get_contract_creation_block.assert_not_awaited()
+
+
+async def test_prefetch_skips_already_cached_senders(
+    checker: TransactionChecker,
+    mock_db: AsyncMock,
+    mock_etherscan: AsyncMock,
+):
+    """Senders already in _contract_creation_cache are not re-queried in bulk."""
+    mock_db.get_recent_transactions.return_value = []
+    mock_db.get_users_for_address.return_value = [USER1]
+    mock_db.get_known_senders.return_value = set()
+    mock_etherscan.get_contract_creation_blocks.return_value = {}
+
+    cached_sender = "0xsender00000000000000000000000000000006cc"
+    fresh_sender = "0xsender00000000000000000000000000000006ff"
+    # Pre-seed the cache for one of the two senders.
+    checker._contract_creation_cache[cached_sender] = 999
+
+    batch = []
+    for i, s in enumerate([cached_sender, fresh_sender]):
+        tx = create_mock_tx(
+            BLOCK_ADDR1_START + 1 + i, s, ADDR1, USDT_CONTRACT,
+            tx_hash=f"0xseeded{i}",
+        )
+        tx["token_symbol"] = "USDT"
+        batch.append(tx)
+
+    await checker._send_notifications_for_batch(
+        [USER1], batch, ADDR1.lower()
+    )
+
+    mock_etherscan.get_contract_creation_blocks.assert_awaited_once()
+    requested = mock_etherscan.get_contract_creation_blocks.await_args.args[0]
+    assert cached_sender not in requested
+    assert fresh_sender in requested
+
+
+async def test_prefetch_skips_bulk_when_cache_smaller_than_batch(
+    checker: TransactionChecker,
+    mock_db: AsyncMock,
+    mock_etherscan: AsyncMock,
+    caplog,
+):
+    """
+    If _contract_creation_cache_max_size < unique senders, pre-fetch is skipped
+    and the per-tx fallback path is used instead, with a warning logged.
+    """
+    mock_db.get_recent_transactions.return_value = []
+    mock_db.get_users_for_address.return_value = [USER1]
+    mock_db.get_known_senders.return_value = set()
+    mock_etherscan.get_contract_creation_block.return_value = None
+
+    # Squeeze the cache so pre-fetch would overflow it.
+    checker._contract_creation_cache_max_size = 1
+
+    senders = [
+        "0xsender0000000000000000000000000000000701",
+        "0xsender0000000000000000000000000000000702",
+        "0xsender0000000000000000000000000000000703",
+    ]
+    batch = []
+    for i, s in enumerate(senders):
+        tx = create_mock_tx(
+            BLOCK_ADDR1_START + 1 + i, s, ADDR1, USDT_CONTRACT,
+            tx_hash=f"0xsmall{i:02d}",
+        )
+        tx["token_symbol"] = "USDT"
+        batch.append(tx)
+
+    with caplog.at_level(logging.WARNING):
+        await checker._send_notifications_for_batch(
+            [USER1], batch, ADDR1.lower()
+        )
+
+    # Bulk path must be skipped...
+    mock_etherscan.get_contract_creation_blocks.assert_not_awaited()
+    # ...and a warning emitted.
+    assert any("contract_creation_cache_size" in r.message for r in caplog.records)
+
+
+async def test_prefetch_continues_when_bulk_db_call_fails(
+    checker: TransactionChecker,
+    mock_db: AsyncMock,
+    mock_etherscan: AsyncMock,
+    mock_notifier: AsyncMock,
+    caplog,
+):
+    """If get_known_senders raises, pre-fetch falls back to empty set and keeps running."""
+    # Spam detection off so we don't couple this test to scoring details;
+    # the point is the pipeline survives a bulk-DB failure without crashing.
+    checker._spam_detection_enabled = False
+    mock_db.get_recent_transactions.return_value = []
+    mock_db.get_users_for_address.return_value = [USER1]
+    mock_db.get_known_senders.side_effect = Exception("boom")
+    mock_etherscan.get_contract_creation_blocks.return_value = {}
+
+    tx = create_mock_tx(
+        BLOCK_ADDR1_START + 1,
+        "0xsender00000000000000000000000000000008ff",
+        ADDR1,
+        USDT_CONTRACT,
+        tx_hash="0xfail01",
+    )
+    tx["token_symbol"] = "USDT"
+
+    with caplog.at_level(logging.WARNING):
+        await checker._send_notifications_for_batch(
+            [USER1], [tx], ADDR1.lower()
+        )
+
+    # Notification still sent despite the bulk DB failure (spam off).
+    mock_notifier.send_token_notification.assert_awaited_once()
+    # Single-address DB fallback must NOT be used — the enrichment context
+    # just treats every sender as "new" when the bulk call fails.
+    mock_db.is_new_sender_address.assert_not_awaited()
+    assert any("Bulk known-senders" in r.message for r in caplog.records)
+
+
+async def test_prefetch_continues_when_bulk_contract_call_fails(
+    checker: TransactionChecker,
+    mock_db: AsyncMock,
+    mock_etherscan: AsyncMock,
+    mock_notifier: AsyncMock,
+    caplog,
+):
+    """If get_contract_creation_blocks raises, pre-fetch logs and keeps running."""
+    checker._spam_detection_enabled = False
+    mock_db.get_recent_transactions.return_value = []
+    mock_db.get_users_for_address.return_value = [USER1]
+    mock_db.get_known_senders.return_value = set()
+    mock_etherscan.get_contract_creation_blocks.side_effect = Exception(
+        "transport dead"
+    )
+    mock_etherscan.get_contract_creation_block.return_value = None
+
+    sender = "0xsender0000000000000000000000000000000901"
+    tx = create_mock_tx(
+        BLOCK_ADDR1_START + 1, sender, ADDR1, USDT_CONTRACT, tx_hash="0xfail02"
+    )
+    tx["token_symbol"] = "USDT"
+
+    with caplog.at_level(logging.WARNING):
+        await checker._send_notifications_for_batch(
+            [USER1], [tx], ADDR1.lower()
+        )
+
+    mock_notifier.send_token_notification.assert_awaited_once()
+    assert any("Bulk contract-creation" in r.message for r in caplog.records)

--- a/tests/test_database.py
+++ b/tests/test_database.py
@@ -305,6 +305,165 @@ async def test_is_new_sender_address(memory_db_manager: DatabaseManager):
     )
 
 
+async def test_get_known_senders_empty_input(memory_db_manager: DatabaseManager):
+    """Empty input list returns empty set without touching the DB."""
+    monitored_addr = "0xcccccccccccccccccccccccccccccccccccccccc"
+    result = await memory_db_manager.get_known_senders(monitored_addr, [])
+    assert result == set()
+
+
+async def test_get_known_senders_returns_only_seen(
+    memory_db_manager: DatabaseManager,
+):
+    """get_known_senders returns the subset of senders already in history."""
+    monitored_addr = "0xcccccccccccccccccccccccccccccccccccccccc"
+    seen1 = "0x1111111111111111111111111111111111111111"
+    seen2 = "0x2222222222222222222222222222222222222222"
+    unseen = "0x3333333333333333333333333333333333333333"
+
+    await memory_db_manager.add_user(30, "user30", "U", "30")
+    await memory_db_manager.add_wallet(30, monitored_addr)
+
+    for tx_hash, sender in [("0xa1", seen1), ("0xa2", seen2)]:
+        await memory_db_manager.store_transaction(
+            tx_hash=tx_hash,
+            monitored_address=monitored_addr,
+            from_address=sender,
+            to_address=monitored_addr,
+            value=1.0,
+            block_number=100,
+            timestamp="2025-01-27T12:00:00+00:00",
+            token_symbol="USDT",
+        )
+
+    known = await memory_db_manager.get_known_senders(
+        monitored_addr, [seen1, seen2, unseen]
+    )
+    assert known == {seen1, seen2}
+    # "new" = input minus known
+    assert {seen1, seen2, unseen} - known == {unseen}
+
+
+async def test_get_known_senders_case_insensitive(
+    memory_db_manager: DatabaseManager,
+):
+    """Mixed-case input is matched against lowercased stored addresses."""
+    monitored_addr = "0xCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC"
+    sender = "0x1111111111111111111111111111111111111111"
+
+    await memory_db_manager.add_user(31, "user31", "U", "31")
+    await memory_db_manager.add_wallet(31, monitored_addr)
+    await memory_db_manager.store_transaction(
+        tx_hash="0xb1",
+        monitored_address=monitored_addr,
+        from_address=sender,
+        to_address=monitored_addr,
+        value=1.0,
+        block_number=100,
+        timestamp="2025-01-27T12:00:00+00:00",
+        token_symbol="USDT",
+    )
+
+    # Query with uppercased monitored AND sender
+    known = await memory_db_manager.get_known_senders(
+        monitored_addr.upper(), [sender.upper()]
+    )
+    assert known == {sender.lower()}
+
+
+async def test_get_known_senders_deduplicates_input(
+    memory_db_manager: DatabaseManager,
+):
+    """Duplicates in the input list collapse to a single result entry."""
+    monitored_addr = "0xcccccccccccccccccccccccccccccccccccccccc"
+    sender = "0x1111111111111111111111111111111111111111"
+
+    await memory_db_manager.add_user(32, "user32", "U", "32")
+    await memory_db_manager.add_wallet(32, monitored_addr)
+    await memory_db_manager.store_transaction(
+        tx_hash="0xc1",
+        monitored_address=monitored_addr,
+        from_address=sender,
+        to_address=monitored_addr,
+        value=1.0,
+        block_number=100,
+        timestamp="2025-01-27T12:00:00+00:00",
+        token_symbol="USDT",
+    )
+
+    known = await memory_db_manager.get_known_senders(
+        monitored_addr, [sender, sender, sender.upper()]
+    )
+    assert known == {sender}
+
+
+async def test_get_known_senders_chunking_over_limit(
+    memory_db_manager: DatabaseManager,
+):
+    """An input list larger than the chunk size still returns correct results.
+
+    Exercises the chunk loop in ``_get_known_senders_sync`` by feeding in
+    more addresses than the 500-placeholder chunk size.
+    """
+    from usdt_monitor_bot.database import DatabaseManager as _DM
+
+    monitored_addr = "0xcccccccccccccccccccccccccccccccccccccccc"
+    await memory_db_manager.add_user(33, "user33", "U", "33")
+    await memory_db_manager.add_wallet(33, monitored_addr)
+
+    # Store 10 senders as "known".
+    known_senders = [f"0x{(0xaa00 + i):040x}" for i in range(10)]
+    for i, s in enumerate(known_senders):
+        await memory_db_manager.store_transaction(
+            tx_hash=f"0xd{i}",
+            monitored_address=monitored_addr,
+            from_address=s,
+            to_address=monitored_addr,
+            value=1.0,
+            block_number=100 + i,
+            timestamp="2025-01-27T12:00:00+00:00",
+            token_symbol="USDT",
+        )
+
+    # Build a query list with 1200 unseen senders + the 10 known ones,
+    # forcing at least 3 query chunks at the default chunk size of 500.
+    unseen = [f"0x{(0xbb0000 + i):040x}" for i in range(1200)]
+    all_query = unseen + known_senders
+    assert _DM._KNOWN_SENDERS_CHUNK_SIZE == 500
+    assert len(all_query) > 2 * _DM._KNOWN_SENDERS_CHUNK_SIZE
+
+    result = await memory_db_manager.get_known_senders(monitored_addr, all_query)
+    assert result == set(known_senders)
+
+
+async def test_get_known_senders_scopes_by_monitored_address(
+    memory_db_manager: DatabaseManager,
+):
+    """A sender known for address A must not leak into the result for address B."""
+    monitored_a = "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa1"
+    monitored_b = "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa2"
+    sender = "0x1111111111111111111111111111111111111111"
+
+    await memory_db_manager.add_user(34, "user34", "U", "34")
+    await memory_db_manager.add_wallet(34, monitored_a)
+    await memory_db_manager.add_wallet(34, monitored_b)
+    await memory_db_manager.store_transaction(
+        tx_hash="0xe1",
+        monitored_address=monitored_a,
+        from_address=sender,
+        to_address=monitored_a,
+        value=1.0,
+        block_number=100,
+        timestamp="2025-01-27T12:00:00+00:00",
+        token_symbol="USDT",
+    )
+
+    assert await memory_db_manager.get_known_senders(monitored_a, [sender]) == {
+        sender
+    }
+    assert await memory_db_manager.get_known_senders(monitored_b, [sender]) == set()
+
+
 async def test_cleanup_old_transactions(memory_db_manager: DatabaseManager):
     """Test cleanup of old transactions."""
     monitored_addr = "0xdddddddddddddddddddddddddddddddddddddddd"
@@ -392,7 +551,9 @@ async def test_database_migration_existing_db(memory_db_manager: DatabaseManager
             fetch_all=True,
         )
     )
-    assert len(indexes) == 2
+    # idx_tx_history_monitored_address + idx_tx_history_timestamp +
+    # idx_tx_history_monitored_from (added for bulk known-senders lookup).
+    assert len(indexes) == 3
 
     # Verify existing data is still intact
     wallets = await memory_db_manager.list_wallets(5)

--- a/tests/test_etherscan.py
+++ b/tests/test_etherscan.py
@@ -649,3 +649,181 @@ async def test_get_contract_creation_block_accepts_valid_block(
     )
     result = await client.get_contract_creation_block("0xcontract")
     assert result == 12345678
+
+
+# --- Batch contract creation tests ---
+
+
+@pytest.mark.asyncio
+async def test_get_contract_creation_blocks_empty_input(
+    etherscan_client_with_mocked_session, mock_aiohttp_session
+):
+    """Empty input returns empty dict without any HTTP calls."""
+    client = etherscan_client_with_mocked_session
+    mock_aiohttp_session.get.reset_mock()
+    result = await client.get_contract_creation_blocks([])
+    assert result == {}
+    mock_aiohttp_session.get.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_get_contract_creation_blocks_single_chunk(
+    etherscan_client_with_mocked_session, mock_aiohttp_session
+):
+    """<=5 addresses go in a single batched request; results keyed by lowercased address."""
+    client = etherscan_client_with_mocked_session
+    addrs = [
+        "0xAaa0000000000000000000000000000000000001",
+        "0xBbb0000000000000000000000000000000000002",
+        "0xCcc0000000000000000000000000000000000003",
+    ]
+    mock_response = mock_aiohttp_session.get.return_value.__aenter__.return_value
+    mock_response.status = 200
+    mock_response.json = AsyncMock(
+        return_value={
+            "status": "1",
+            "result": [
+                {"contractAddress": addrs[0].lower(), "blockNumber": "100"},
+                {"contractAddress": addrs[1].lower(), "blockNumber": "200"},
+                {"contractAddress": addrs[2].lower(), "blockNumber": "300"},
+            ],
+        }
+    )
+    mock_aiohttp_session.get.reset_mock()
+
+    result = await client.get_contract_creation_blocks(addrs)
+
+    assert result == {
+        addrs[0].lower(): 100,
+        addrs[1].lower(): 200,
+        addrs[2].lower(): 300,
+    }
+    assert mock_aiohttp_session.get.call_count == 1
+    # Confirm the API received the 3 addresses as a comma-separated list
+    call_params = mock_aiohttp_session.get.call_args.kwargs["params"]
+    assert call_params["action"] == "getcontractcreation"
+    csv = call_params["contractaddresses"]
+    assert set(csv.split(",")) == {a.lower() for a in addrs}
+
+
+@pytest.mark.asyncio
+async def test_get_contract_creation_blocks_chunks_by_5(
+    etherscan_client_with_mocked_session, mock_aiohttp_session
+):
+    """12 addresses result in ceil(12/5) == 3 HTTP calls."""
+    client = etherscan_client_with_mocked_session
+    addrs = [f"0x{(0xa0 + i):040x}" for i in range(12)]
+    mock_response = mock_aiohttp_session.get.return_value.__aenter__.return_value
+    mock_response.status = 200
+    # Return the same static payload for each chunk; the fact that addresses
+    # are missing from the response is handled (they become None), but here
+    # we just want to count HTTP calls, so return an empty result list.
+    mock_response.json = AsyncMock(return_value={"status": "1", "result": []})
+    mock_aiohttp_session.get.reset_mock()
+
+    result = await client.get_contract_creation_blocks(addrs)
+
+    assert mock_aiohttp_session.get.call_count == 3
+    # All 12 addresses should be present in the result, mapped to None.
+    assert set(result.keys()) == {a.lower() for a in addrs}
+    assert all(v is None for v in result.values())
+
+
+@pytest.mark.asyncio
+async def test_get_contract_creation_blocks_deduplicates_input(
+    etherscan_client_with_mocked_session, mock_aiohttp_session
+):
+    """Duplicate / mixed-case addresses are deduplicated before chunking."""
+    client = etherscan_client_with_mocked_session
+    addr = "0xAAAaaaAAAAAAaaaaaaAAaaAaaaaaAaAaaaaaAaAa"
+    mock_response = mock_aiohttp_session.get.return_value.__aenter__.return_value
+    mock_response.status = 200
+    mock_response.json = AsyncMock(
+        return_value={
+            "status": "1",
+            "result": [{"contractAddress": addr.lower(), "blockNumber": "42"}],
+        }
+    )
+    mock_aiohttp_session.get.reset_mock()
+
+    result = await client.get_contract_creation_blocks(
+        [addr, addr.lower(), addr.upper()]
+    )
+    assert result == {addr.lower(): 42}
+    # One input once -> one HTTP call.
+    assert mock_aiohttp_session.get.call_count == 1
+
+
+@pytest.mark.asyncio
+async def test_get_contract_creation_blocks_missing_entries_are_none(
+    etherscan_client_with_mocked_session, mock_aiohttp_session
+):
+    """Addresses absent from the API response are mapped to None."""
+    client = etherscan_client_with_mocked_session
+    addrs = [
+        "0x" + "a" * 40,
+        "0x" + "b" * 40,
+        "0x" + "c" * 40,
+    ]
+    mock_response = mock_aiohttp_session.get.return_value.__aenter__.return_value
+    mock_response.status = 200
+    # API only returns data for 2 of the 3 addresses.
+    mock_response.json = AsyncMock(
+        return_value={
+            "status": "1",
+            "result": [
+                {"contractAddress": addrs[0], "blockNumber": "1"},
+                {"contractAddress": addrs[2], "blockNumber": "3"},
+            ],
+        }
+    )
+    mock_aiohttp_session.get.reset_mock()
+
+    result = await client.get_contract_creation_blocks(addrs)
+    assert result == {addrs[0]: 1, addrs[1]: None, addrs[2]: 3}
+
+
+@pytest.mark.asyncio
+async def test_get_contract_creation_blocks_rejects_out_of_range(
+    etherscan_client_with_mocked_session, mock_aiohttp_session
+):
+    """Entries with a block number outside the valid range are mapped to None."""
+    client = etherscan_client_with_mocked_session
+    addrs = ["0x" + "a" * 40, "0x" + "b" * 40]
+    mock_response = mock_aiohttp_session.get.return_value.__aenter__.return_value
+    mock_response.status = 200
+    mock_response.json = AsyncMock(
+        return_value={
+            "status": "1",
+            "result": [
+                {"contractAddress": addrs[0], "blockNumber": "100"},
+                {
+                    "contractAddress": addrs[1],
+                    "blockNumber": str(_MAX_VALID_BLOCK_NUMBER + 1),
+                },
+            ],
+        }
+    )
+    mock_aiohttp_session.get.reset_mock()
+
+    result = await client.get_contract_creation_blocks(addrs)
+    assert result[addrs[0]] == 100
+    assert result[addrs[1]] is None
+
+
+@pytest.mark.asyncio
+async def test_get_contract_creation_blocks_api_error_returns_empty(
+    etherscan_client_with_mocked_session, mock_aiohttp_session
+):
+    """status != '1' is treated as empty result and all addresses map to None."""
+    client = etherscan_client_with_mocked_session
+    addrs = ["0x" + "a" * 40, "0x" + "b" * 40]
+    mock_response = mock_aiohttp_session.get.return_value.__aenter__.return_value
+    mock_response.status = 200
+    mock_response.json = AsyncMock(
+        return_value={"status": "0", "message": "NOTOK", "result": "rate limited"}
+    )
+    mock_aiohttp_session.get.reset_mock()
+
+    result = await client.get_contract_creation_blocks(addrs)
+    assert result == {addrs[0]: None, addrs[1]: None}

--- a/tests/test_moralis.py
+++ b/tests/test_moralis.py
@@ -233,6 +233,27 @@ async def test_get_contract_creation_block_returns_none_on_non_200(mock_config):
     assert result is None
 
 
+# --- get_contract_creation_blocks (bulk loops single-address) ---
+
+
+async def test_moralis_bulk_loops_single_address(mock_config):
+    """Moralis's current endpoint has no native batch; bulk method loops."""
+    addrs = ["0x" + "a" * 40, "0x" + "b" * 40]
+    client = MoralisClient(mock_config)
+    client.get_contract_creation_block = AsyncMock(side_effect=[111, 222])
+
+    result = await client.get_contract_creation_blocks(addrs)
+    assert result == {addrs[0]: 111, addrs[1]: 222}
+    assert client.get_contract_creation_block.await_count == 2
+
+
+async def test_moralis_bulk_empty_input(mock_config):
+    client = MoralisClient(mock_config)
+    client.get_contract_creation_block = AsyncMock()
+    assert await client.get_contract_creation_blocks([]) == {}
+    client.get_contract_creation_block.assert_not_awaited()
+
+
 # --- close ---
 
 

--- a/tests/test_with_fallback.py
+++ b/tests/test_with_fallback.py
@@ -246,3 +246,82 @@ async def test_circuit_breaker_recovery_after_cooldown():
     assert result == SAMPLE_TXS
     primary.get_token_transactions.assert_awaited_once()
     assert primary_breaker._opened_at is None  # circuit closed
+
+
+# --- get_contract_creation_blocks (bulk) ---
+
+
+async def test_bulk_primary_success_no_fallback():
+    """Primary returns data, fallback not called."""
+    primary = _make_provider()
+    primary.get_contract_creation_blocks = AsyncMock(
+        return_value={"0xa": 100, "0xb": 200}
+    )
+    fallback = _make_provider()
+    fallback.get_contract_creation_blocks = AsyncMock(return_value={})
+    client = WithFallback(primary=primary, fallbacks=[fallback])
+
+    result = await client.get_contract_creation_blocks(["0xa", "0xb"])
+    assert result == {"0xa": 100, "0xb": 200}
+    primary.get_contract_creation_blocks.assert_awaited_once()
+    fallback.get_contract_creation_blocks.assert_not_awaited()
+
+
+async def test_bulk_empty_input_returns_empty():
+    """Empty input short-circuits to empty dict without touching providers."""
+    primary = _make_provider()
+    primary.get_contract_creation_blocks = AsyncMock(return_value={"should": "skip"})
+    client = WithFallback(primary=primary, fallbacks=[])
+
+    result = await client.get_contract_creation_blocks([])
+    assert result == {}
+    primary.get_contract_creation_blocks.assert_not_awaited()
+
+
+async def test_bulk_primary_raises_falls_over_to_fallback():
+    """Transport-level error on primary triggers fallback with full address list."""
+    primary = _make_provider()
+    primary.get_contract_creation_blocks = AsyncMock(side_effect=aiohttp.ClientError("boom"))
+    fallback = _make_provider()
+    fallback.get_contract_creation_blocks = AsyncMock(return_value={"0xa": 7})
+    client = WithFallback(primary=primary, fallbacks=[fallback])
+
+    result = await client.get_contract_creation_blocks(["0xa"])
+    assert result == {"0xa": 7}
+    primary.get_contract_creation_blocks.assert_awaited_once()
+    fallback.get_contract_creation_blocks.assert_awaited_once_with(["0xa"])
+
+
+async def test_bulk_partial_none_is_authoritative_no_fallback_requery():
+    """
+    None entries in the primary's response are treated as authoritative
+    (`not a contract`) and are NOT re-queried against fallbacks \u2014 re-querying
+    would reintroduce the N+1 this feature eliminates.
+    """
+    primary = _make_provider()
+    primary.get_contract_creation_blocks = AsyncMock(
+        return_value={"0xa": 100, "0xb": None}
+    )
+    fallback = _make_provider()
+    fallback.get_contract_creation_blocks = AsyncMock(
+        return_value={"0xa": 999, "0xb": 999}
+    )
+    client = WithFallback(primary=primary, fallbacks=[fallback])
+
+    result = await client.get_contract_creation_blocks(["0xa", "0xb"])
+    assert result == {"0xa": 100, "0xb": None}
+    fallback.get_contract_creation_blocks.assert_not_awaited()
+
+
+async def test_bulk_all_providers_fail_reraises():
+    """When every provider raises, the last exception is reraised."""
+    primary = _make_provider()
+    primary.get_contract_creation_blocks = AsyncMock(side_effect=EtherscanError("a"))
+    fallback = _make_provider()
+    fallback.get_contract_creation_blocks = AsyncMock(side_effect=ProviderError("b"))
+    client = WithFallback(primary=primary, fallbacks=[fallback])
+
+    with pytest.raises(ProviderError):
+        await client.get_contract_creation_blocks(["0xa"])
+    primary.get_contract_creation_blocks.assert_awaited_once()
+    fallback.get_contract_creation_blocks.assert_awaited_once()

--- a/usdt_monitor_bot/blockchain_provider.py
+++ b/usdt_monitor_bot/blockchain_provider.py
@@ -29,7 +29,46 @@ class BlockchainProvider(Protocol):
         self, contract_address: str
     ) -> int | None: ...
 
+    async def get_contract_creation_blocks(
+        self, contract_addresses: list[str]
+    ) -> dict[str, int | None]:
+        """Bulk variant of ``get_contract_creation_block``.
+
+        Returns a mapping from lowercased address to creation block number, or
+        None if the address is not a contract / lookup failed for that entry.
+        Providers that lack native batch support should inherit the default
+        loop implementation via :func:`default_get_contract_creation_blocks`.
+        """
+        ...
+
     async def close(self) -> None: ...
+
+
+async def default_get_contract_creation_blocks(
+    provider: BlockchainProvider, contract_addresses: list[str]
+) -> dict[str, int | None]:
+    """Fallback implementation for providers without a native batch endpoint.
+
+    Loops ``get_contract_creation_block`` per address. Used by Blockscout and
+    Moralis clients, whose upstream APIs only accept a single address per call.
+    Exceptions from individual lookups are swallowed and recorded as ``None``,
+    mirroring the existing per-address error handling.
+    """
+    result: dict[str, int | None] = {}
+    for raw in contract_addresses:
+        if not raw:
+            continue
+        addr = raw.lower()
+        if addr in result:
+            continue
+        try:
+            result[addr] = await provider.get_contract_creation_block(addr)
+        except (TimeoutError, EtherscanError, ProviderError, aiohttp.ClientError) as e:
+            logging.debug(
+                f"default bulk contract-creation: {addr[:10]}... failed: {e}"
+            )
+            result[addr] = None
+    return result
 
 
 class ProviderCircuitBreaker:
@@ -142,6 +181,48 @@ class WithFallback:
         return await self._call_with_fallback(
             "get_contract_creation_block", contract_address
         )
+
+    async def get_contract_creation_blocks(
+        self, contract_addresses: list[str]
+    ) -> dict[str, int | None]:
+        """Bulk variant that falls back across providers on *transport* failure.
+
+        Semantics:
+        - Calls the first available provider's batch method with the full list.
+        - A raised transport-level error (EtherscanError / ProviderError /
+          aiohttp.ClientError / TimeoutError) trips the circuit breaker and
+          fails over to the next provider, same as the single-address variant.
+        - ``None`` entries in the returned mapping are treated as *authoritative*
+          ("not a contract" / "not found") and are NOT re-queried against
+          fallbacks. Re-querying would amplify the N+1 we are eliminating,
+          because fallback providers loop per-address internally.
+        """
+        if not contract_addresses:
+            return {}
+        last_exc: Exception | None = None
+        for provider, breaker in zip(self._providers, self._breakers, strict=True):
+            if not breaker.is_available():
+                continue
+            if breaker.is_recovering():
+                logging.info(
+                    f"Provider {type(provider).__name__} attempting recovery..."
+                )
+            try:
+                result = await provider.get_contract_creation_blocks(
+                    contract_addresses
+                )
+                breaker.record_success()
+                return result
+            except (TimeoutError, EtherscanError, ProviderError, aiohttp.ClientError) as e:
+                logging.warning(
+                    f"Provider {type(provider).__name__} failed "
+                    f"[get_contract_creation_blocks]: {e}"
+                )
+                breaker.record_failure()
+                last_exc = e
+        if last_exc is not None:
+            raise last_exc
+        raise RuntimeError("All providers unavailable (all circuit breakers open)")
 
     async def close(self) -> None:
         for provider in self._providers:

--- a/usdt_monitor_bot/blockscout.py
+++ b/usdt_monitor_bot/blockscout.py
@@ -7,7 +7,10 @@ from datetime import datetime
 import aiohttp
 from aiohttp import ClientTimeout, TCPConnector
 
-from usdt_monitor_bot.blockchain_provider import ProviderError
+from usdt_monitor_bot.blockchain_provider import (
+    ProviderError,
+    default_get_contract_creation_blocks,
+)
 from usdt_monitor_bot.config import BotConfig
 from usdt_monitor_bot.etherscan import AdaptiveRateLimiter
 
@@ -161,6 +164,18 @@ class BlockscoutClient:
                 return block_number
         except (ValueError, TypeError):
             return None
+
+    async def get_contract_creation_blocks(
+        self, contract_addresses: list[str]
+    ) -> dict[str, int | None]:
+        """Bulk variant — no native batch endpoint on Blockscout v2 REST.
+
+        Blockscout's ``GET /api/v2/addresses/{address}`` takes the address in
+        the URL path and has no filter-by-list variant, so we fall back to
+        the default loop implementation. Expected to be a cold path because
+        Blockscout is a fallback provider.
+        """
+        return await default_get_contract_creation_blocks(self, contract_addresses)
 
     async def get_contract_creation_block(
         self, contract_address: str

--- a/usdt_monitor_bot/checker.py
+++ b/usdt_monitor_bot/checker.py
@@ -46,6 +46,22 @@ class AddressProcessingResult:
     max_block_in_processed_batch: int  # 0 if no batch was processed
 
 
+@dataclass
+class EnrichmentContext:
+    """Pre-fetched enrichment data shared across a batch of txs for one address.
+
+    Populated once per address before the per-tx loop to eliminate the N+1
+    query pattern in spam detection. ``known_senders`` is a mutable set
+    intentionally — the per-tx loop adds newly-observed senders as it goes
+    so that the same sender appearing twice in one batch is classified as
+    "new" only on its first occurrence, matching the pre-batching semantics
+    (the old code ran ``store_transaction`` between iterations and would
+    flip the DB state mid-loop).
+    """
+
+    known_senders: set[str]
+
+
 class TransactionChecker:
     """Periodically checks for new token transactions for monitored addresses."""
 
@@ -217,29 +233,48 @@ class TransactionChecker:
         tx_metadata: TransactionMetadata,
         address_lower: str,
         historical_metadata: list[TransactionMetadata],
+        ctx: EnrichmentContext | None = None,
     ) -> RiskAnalysis:
         """
         Enrich transaction metadata with spam detection data and perform risk analysis.
+
+        When ``ctx`` is provided, sender-history and contract-age data are
+        read from the pre-fetched context / contract-creation cache instead
+        of hitting the DB and Etherscan per transaction. ``ctx`` is mutated
+        to mark the current sender as known for subsequent iterations
+        within the same batch.
 
         Args:
             tx_metadata: Transaction metadata to enrich
             address_lower: The monitored address
             historical_metadata: Historical transactions for context
+            ctx: Optional pre-fetched enrichment context (batch mode).
+                If None, falls back to per-tx DB / Etherscan lookups.
 
         Returns:
             RiskAnalysis object
         """
-        # Check if sender is new
-        is_new_sender = await self._db.is_new_sender_address(
-            address_lower, tx_metadata.from_address
-        )
-        tx_metadata.is_new_address = is_new_sender
+        sender_lower = tx_metadata.from_address.lower()
 
-        # Get contract age (with caching)
-        contract_age = await self._get_contract_age_blocks(
+        # Check if sender is new — batch path reads from the pre-fetched set,
+        # fallback path does a single-address DB lookup.
+        if ctx is not None:
+            tx_metadata.is_new_address = sender_lower not in ctx.known_senders
+            # Mark as seen so repeated senders in the same batch don't all
+            # get flagged as "new" (matches pre-batching semantics where
+            # store_transaction() ran between iterations).
+            ctx.known_senders.add(sender_lower)
+        else:
+            tx_metadata.is_new_address = await self._db.is_new_sender_address(
+                address_lower, tx_metadata.from_address
+            )
+
+        # Get contract age. Batch mode pre-populates the cache, so this is
+        # a pure in-memory lookup in the common case; cold cache falls back
+        # to the per-address path.
+        tx_metadata.contract_age_blocks = await self._get_contract_age_blocks(
             tx_metadata.from_address, tx_metadata.block_number
         )
-        tx_metadata.contract_age_blocks = contract_age
 
         # Build whitelist of trusted addresses (token contracts only)
         # The monitored address is passed separately to enable spam detection on incoming transactions
@@ -310,6 +345,7 @@ class TransactionChecker:
         user_ids: list[int],
         address_lower: str,
         historical_metadata: list[TransactionMetadata],
+        enrichment_ctx: EnrichmentContext | None = None,
     ) -> int:
         """
         Process a single transaction: analyze, store, log, and notify.
@@ -349,7 +385,10 @@ class TransactionChecker:
             tx_metadata = convert_to_transaction_metadata(tx, token_config.decimals)
             if tx_metadata:
                 risk_analysis = await self._enrich_transaction_metadata(
-                    tx_metadata, address_lower, historical_metadata
+                    tx_metadata,
+                    address_lower,
+                    historical_metadata,
+                    enrichment_ctx,
                 )
                 historical_metadata.append(tx_metadata)
 
@@ -394,6 +433,82 @@ class TransactionChecker:
                 self._remove_notification_sent(user_id, tx_hash)
         return sent_count
 
+    async def _prefetch_enrichment_context(
+        self, batch: list[dict], address_lower: str
+    ) -> EnrichmentContext:
+        """Pre-fetch sender history and contract ages for an entire batch.
+
+        Eliminates the N+1 query pattern in the per-tx spam detection loop by:
+        1. A single bulk ``get_known_senders`` DB query for all unique senders.
+        2. A batched ``get_contract_creation_blocks`` HTTP call for all
+           uncached senders, which populates ``_contract_creation_cache``.
+
+        If the contract-creation cache is too small to hold all unique
+        senders in this batch (a config smell), logs a warning and skips
+        bulk pre-fetch for contract ages — the per-tx path will fall back
+        to single-address lookups, matching pre-feature behaviour.
+        """
+        unique_senders = list(
+            {
+                (tx.get("from") or "").lower()
+                for tx in batch
+                if tx.get("from")
+            }
+        )
+
+        # 1. Bulk sender-history lookup: 1 DB roundtrip instead of N.
+        known_senders: set[str] = set()
+        if unique_senders:
+            try:
+                known_senders = await self._db.get_known_senders(
+                    address_lower, unique_senders
+                )
+            except Exception as e:
+                logging.warning(
+                    f"Bulk known-senders lookup failed for {address_lower[:8]}...: {e}",
+                    exc_info=True,
+                )
+                known_senders = set()
+
+        # 2. Bulk contract-age pre-fetch: only addresses not already cached.
+        uncached = [
+            s
+            for s in unique_senders
+            if s and s not in self._contract_creation_cache
+        ]
+        if uncached:
+            # Guard against a cache smaller than the batch's unique senders:
+            # if we pre-fetched N addresses into a cache of size < N, we would
+            # start evicting our own pre-fetched data mid-loop. Fall back to
+            # the per-tx path and flag the misconfiguration.
+            if len(uncached) > self._contract_creation_cache_max_size:
+                logging.warning(
+                    f"Skipping bulk contract-creation pre-fetch for "
+                    f"{address_lower[:8]}...: {len(uncached)} uncached senders "
+                    f"> cache size {self._contract_creation_cache_max_size}. "
+                    f"Consider raising contract_creation_cache_size."
+                )
+            else:
+                try:
+                    creation_blocks = (
+                        await self._etherscan.get_contract_creation_blocks(uncached)
+                    )
+                except Exception as e:
+                    logging.warning(
+                        f"Bulk contract-creation lookup failed for "
+                        f"{address_lower[:8]}...: {e}",
+                        exc_info=True,
+                    )
+                    creation_blocks = {}
+                # Cache every address we asked about — including explicit
+                # misses — so the next cycle does not re-query them.
+                for addr in uncached:
+                    self._cache_contract_block(
+                        addr, creation_blocks.get(addr)
+                    )
+
+        return EnrichmentContext(known_senders=known_senders)
+
     async def _send_notifications_for_batch(
         self, user_ids: list[int], batch: list[dict], address_lower: str
     ) -> None:
@@ -409,11 +524,19 @@ class TransactionChecker:
             address_lower, limit=20
         )
 
+        # Bulk pre-fetch sender-history + contract ages for the whole batch,
+        # so the per-tx loop below is a pure in-memory lookup in the common case.
+        enrichment_ctx = await self._prefetch_enrichment_context(batch, address_lower)
+
         notifications_sent = 0
         for tx in batch:
             try:
                 notifications_sent += await self._process_single_transaction(
-                    tx, user_ids, address_lower, historical_metadata
+                    tx,
+                    user_ids,
+                    address_lower,
+                    historical_metadata,
+                    enrichment_ctx,
                 )
             except Exception as e:
                 logging.error(

--- a/usdt_monitor_bot/database.py
+++ b/usdt_monitor_bot/database.py
@@ -201,6 +201,13 @@ class DatabaseManager:
                    ON transaction_history(monitored_address, block_number DESC)""",
             """CREATE INDEX IF NOT EXISTS idx_tx_history_timestamp
                    ON transaction_history(timestamp)""",
+            # Speeds up get_known_senders() bulk lookup: the existing
+            # (monitored_address, block_number DESC) index does not help a filter
+            # on from_address. This composite index makes the IN (...) query
+            # index-only for the bulk sender check in the spam detection path.
+            """CREATE INDEX IF NOT EXISTS idx_tx_history_monitored_from
+                   ON transaction_history(monitored_address, from_address)""",
+
             # Speeds up get_users_for_address: the existing UNIQUE(user_id, address)
             # index cannot be used for address-only lookups, forcing a full scan
             # on every checker cycle x monitored address.
@@ -521,6 +528,56 @@ class DatabaseManager:
         )
         return result is None
 
+    # Chunk size for the IN (...) placeholder list in _get_known_senders_sync.
+    # SQLite's SQLITE_MAX_VARIABLE_NUMBER is 32766 on modern builds but was 999
+    # on older builds; 500 stays comfortably below both and keeps each query
+    # cheap. +1 is for the monitored_address param itself.
+    _KNOWN_SENDERS_CHUNK_SIZE = 500
+
+    def _get_known_senders_sync(
+        self, monitored_address: str, sender_addresses: list[str]
+    ) -> set[str]:
+        """
+        Return the subset of ``sender_addresses`` already seen for
+        ``monitored_address`` in transaction_history.
+
+        Bulk replacement for per-tx ``is_new_sender_address`` calls in the
+        spam detection hot path. Input addresses are lowercased; the returned
+        set contains lowercased addresses.
+
+        Args:
+            monitored_address: The address being monitored
+            sender_addresses: Candidate sender addresses to check
+
+        Returns:
+            Set of lowercased sender addresses that already exist in history.
+            Empty set on empty input or DB error.
+        """
+        if not sender_addresses:
+            return set()
+
+        monitored_lower = monitored_address.lower()
+        # Deduplicate + lowercase first so we don't waste placeholders.
+        unique = list({s.lower() for s in sender_addresses if s})
+        if not unique:
+            return set()
+
+        known: set[str] = set()
+        chunk_size = self._KNOWN_SENDERS_CHUNK_SIZE
+        for i in range(0, len(unique), chunk_size):
+            chunk = unique[i : i + chunk_size]
+            placeholders = ",".join("?" * len(chunk))
+            query = (
+                "SELECT DISTINCT from_address FROM transaction_history "
+                f"WHERE monitored_address = ? AND from_address IN ({placeholders})"  # nosec B608
+            )
+            rows = self._execute_db_query(
+                query, (monitored_lower, *chunk), fetch_all=True
+            )
+            if rows:
+                known.update(row[0] for row in rows)
+        return known
+
     # --- Async Public Methods for Transaction History ---
     async def store_transaction(
         self,
@@ -568,6 +625,22 @@ class DatabaseManager:
         """Check if a sender address has been seen before."""
         return await self._run_sync_db_operation(
             self._is_new_sender_address_sync, monitored_address, sender_address
+        )
+
+    async def get_known_senders(
+        self, monitored_address: str, sender_addresses: list[str]
+    ) -> set[str]:
+        """Bulk variant of ``is_new_sender_address``.
+
+        Returns the subset of ``sender_addresses`` (lowercased) that already
+        appear in transaction_history for ``monitored_address``. A sender is
+        "new" iff it is in the input list but not in the returned set.
+
+        Used by the spam detection path to replace N per-tx DB roundtrips
+        with a single bulk query per batch.
+        """
+        return await self._run_sync_db_operation(
+            self._get_known_senders_sync, monitored_address, sender_addresses
         )
 
     # --- Spam Transaction Operations ---

--- a/usdt_monitor_bot/etherscan.py
+++ b/usdt_monitor_bot/etherscan.py
@@ -496,6 +496,146 @@ class EtherscanClient:
             logging.debug(f"Contract creation error {contract_address[:10]}...: {e}")
             return None
 
+    # Etherscan's getcontractcreation endpoint accepts a comma-separated
+    # `contractaddresses` list of up to 5 addresses per call. We chunk at this
+    # cap and issue one HTTP request per chunk.
+    _CONTRACT_CREATION_BATCH_SIZE = 5
+
+    async def get_contract_creation_blocks(
+        self, contract_addresses: list[str]
+    ) -> dict[str, int | None]:
+        """Batch variant of :meth:`get_contract_creation_block`.
+
+        Chunks the input list into groups of up to ``_CONTRACT_CREATION_BATCH_SIZE``
+        addresses, issues one ``getcontractcreation`` request per chunk, and
+        merges the results into a dict keyed by lowercased address.
+
+        Addresses absent from the API response are mapped to ``None``
+        (treated as "not a contract" or not found).
+
+        On per-chunk *transport* failure, the chunk degrades gracefully to
+        single-address calls so one bad address cannot black-hole the other
+        four. Rate-limit errors inside the chunk are propagated upward, so
+        the @retry layer around the outer call can handle them uniformly.
+
+        Args:
+            contract_addresses: Candidate contract addresses. Duplicates and
+                falsy entries are ignored.
+
+        Returns:
+            Dict mapping lowercased address -> creation block number or None.
+        """
+        if not contract_addresses:
+            return {}
+
+        # Deduplicate + lowercase, preserving order for deterministic chunking.
+        unique: list[str] = []
+        seen: set[str] = set()
+        for raw in contract_addresses:
+            if not raw:
+                continue
+            lower = raw.lower()
+            if lower in seen:
+                continue
+            seen.add(lower)
+            unique.append(lower)
+        if not unique:
+            return {}
+
+        await self._ensure_session()
+        result: dict[str, int | None] = {}
+        chunk_size = self._CONTRACT_CREATION_BATCH_SIZE
+        for i in range(0, len(unique), chunk_size):
+            chunk = unique[i : i + chunk_size]
+            try:
+                chunk_result = await self._fetch_contract_creation_chunk(chunk)
+            except (TimeoutError, aiohttp.ClientError, EtherscanError) as e:
+                # Per-chunk failure: fall back to single-address calls so one
+                # bad address in the chunk cannot poison the other four. The
+                # single-address method already swallows its own errors and
+                # returns None.
+                logging.debug(
+                    f"Batch contract-creation chunk failed ({len(chunk)} addrs): "
+                    f"{e}; falling back to per-address"
+                )
+                chunk_result = {}
+                for addr in chunk:
+                    chunk_result[addr] = await self.get_contract_creation_block(addr)
+            # Ensure every requested address in this chunk has an entry, even
+            # if the API omitted it. Absent == None.
+            for addr in chunk:
+                result.setdefault(addr, chunk_result.get(addr))
+        return result
+
+    async def _fetch_contract_creation_chunk(
+        self, chunk: list[str]
+    ) -> dict[str, int | None]:
+        """Fetch a single chunk of up to 5 contract creation records.
+
+        Returns a dict mapping lowercased address -> creation block number.
+        Missing addresses are not added to the dict (caller fills in None).
+        """
+        params = {
+            "chainid": "1",
+            "module": "contract",
+            "action": "getcontractcreation",
+            "contractaddresses": ",".join(chunk),
+            "apikey": self._api_key,
+        }
+        session = self._session
+        if session is None:
+            raise RuntimeError("HTTP session not initialized")
+
+        async def _make_request() -> dict[str, int | None]:
+            async with session.get(self._base_url, params=params) as response:
+                if response.status == 429:
+                    raise EtherscanRateLimitError("Rate limit exceeded")
+                if response.status != 200:
+                    logging.debug(
+                        f"Batch contract creation API status={response.status}"
+                    )
+                    return {}
+                data = await response.json()
+                if data.get("status") != "1":
+                    return {}
+                result_list = data.get("result", [])
+                if not isinstance(result_list, list):
+                    return {}
+                parsed: dict[str, int | None] = {}
+                for entry in result_list:
+                    if not isinstance(entry, dict):
+                        continue
+                    addr = (entry.get("contractAddress") or "").lower()
+                    if not addr:
+                        continue
+                    block_number = entry.get("blockNumber")
+                    if block_number is None:
+                        parsed[addr] = None
+                        continue
+                    try:
+                        parsed_block = int(block_number)
+                        if not (0 < parsed_block <= _MAX_VALID_BLOCK_NUMBER):
+                            logging.warning(
+                                f"Contract creation block out of range: {parsed_block}"
+                            )
+                            parsed[addr] = None
+                        else:
+                            parsed[addr] = parsed_block
+                    except (ValueError, TypeError):
+                        logging.debug(f"Invalid block number: {block_number}")
+                        parsed[addr] = None
+                return parsed
+
+        try:
+            return await self._make_request_with_rate_limiting(_make_request)
+        except EtherscanRateLimitError:
+            logging.debug(
+                f"Rate limited: batch contract creation ({len(chunk)} addrs)"
+            )
+            return {}
+        except ValueError as e:  # JSON decoding error
+            raise EtherscanError(f"Invalid JSON response: {e}") from e
+
     @retry(
         stop=stop_after_attempt(3),
         wait=wait_exponential(multiplier=1, min=1, max=5),

--- a/usdt_monitor_bot/moralis.py
+++ b/usdt_monitor_bot/moralis.py
@@ -7,7 +7,10 @@ from datetime import UTC, datetime
 import aiohttp
 from aiohttp import ClientTimeout, TCPConnector
 
-from usdt_monitor_bot.blockchain_provider import ProviderError
+from usdt_monitor_bot.blockchain_provider import (
+    ProviderError,
+    default_get_contract_creation_blocks,
+)
 from usdt_monitor_bot.config import BotConfig
 
 _MAX_VALID_BLOCK_NUMBER = 10**9
@@ -158,6 +161,20 @@ class MoralisClient:
             return None
         except (ValueError, TypeError):
             return None
+
+    async def get_contract_creation_blocks(
+        self, contract_addresses: list[str]
+    ) -> dict[str, int | None]:
+        """Bulk variant — loops single-address calls.
+
+        Moralis does offer a bulk ``/erc20/metadata?addresses=...`` endpoint
+        (up to 25 per call) that returns ``block_number``, but it has a
+        different shape from the endpoint we currently use, and Moralis is
+        fallback #2 (only hit when Etherscan + Blockscout circuits are both
+        open). Out of scope for this feature — file as a follow-up if
+        Moralis ever becomes the hot path.
+        """
+        return await default_get_contract_creation_blocks(self, contract_addresses)
 
     async def get_contract_creation_block(
         self, contract_address: str


### PR DESCRIPTION
## Summary

Eliminates the N+1 query pattern in the spam detection hot path. For each transaction, the old code did one DB roundtrip (`is_new_sender_address`) and one Etherscan call (`get_contract_creation_block`). At 500k txs per cycle this was ~1.5M extra per-tx calls and dominated wall-clock on large workloads.

The new `_prefetch_enrichment_context` makes **two bulk calls per address** before the per-tx loop:

1. **`DatabaseManager.get_known_senders`** — a single `IN (...)` query over all unique senders in the batch, replacing N `is_new_sender_address` calls. Chunked at 500 placeholders for safety on older SQLite builds. Backed by a new `idx_tx_history_monitored_from` composite index.

2. **`BlockchainProvider.get_contract_creation_blocks`** — Etherscan's `getcontractcreation` endpoint already accepts up to 5 addresses per comma-separated request (the `contractaddresses` param is plural in the existing code and the response is already a list). We chunk into groups of 5 and issue one HTTP call per chunk. Per-chunk transport failures degrade to single-address calls so one bad address cannot black-hole the other four. Results populate `_contract_creation_cache` including explicit misses (so the next cycle won't re-query them).

## Expected impact

At 10k unique senders / 500k txs / cycle with a cold cache:

| Call | Before | After |
|---|---|---|
| `is_new_sender_address` DB roundtrips | ~500 000 | ≤ 20 (one per ⌈unique_senders / 500⌉ chunk) |
| `getcontractcreation` HTTP calls | ≤ 10 000 | ≤ 2 000 (⌈unique_senders / 5⌉) |

## Per-provider batch support

Verified against each provider's current implementation:

| Provider | Endpoint | Batch? | Limit |
|---|---|---|---|
| **Etherscan** | `contract/getcontractcreation?contractaddresses=<csv>` | ✅ native | **5** per call |
| **Blockscout** | REST v2 `GET /api/v2/addresses/{address}` | ❌ (URL-path address) | 1 |
| **Moralis** | `GET /api/v2.2/{contract_address}` | ❌ on current endpoint | 1 |

Only `EtherscanClient` gets a real override. `BlockscoutClient` and `MoralisClient` inherit the new `default_get_contract_creation_blocks` helper which just loops per-address (no client rewrite needed). Moralis does expose a bulk `/erc20/metadata?addresses=...` endpoint (up to 25) but it is a different endpoint shape, and Moralis is fallback #2, so migrating is left as a documented follow-up.

## Fallback semantics (important)

`WithFallback.get_contract_creation_blocks`:

- **Transport error on primary → fail over** to the next provider with the full address list (same policy as the single-address variant).
- **`None` entries in the primary response are authoritative** ("not a contract") and are **not** re-queried against fallbacks. Re-querying would amplify the N+1 we are eliminating, because Blockscout/Moralis loop per-address internally.
- Per-chunk Etherscan failure inside the batch method degrades that specific chunk to single-address calls, so one bad address cannot poison the other four.

## Semantic preservation

`EnrichmentContext.known_senders` is **mutated mid-loop** so a sender appearing twice in the same batch is classified as "new" only on its first occurrence. This matches pre-batching semantics where `store_transaction` ran between iterations and would have flipped the DB state between successive `is_new_sender_address` calls. Covered by `test_prefetch_same_sender_twice_second_is_not_new`.

## Safety rails

- **Cache overflow guard**: if `contract_creation_cache_size` is smaller than the number of unique senders in a batch, bulk pre-fetch is skipped with a warning pointing at the config variable (otherwise we would evict our own pre-fetched data mid-loop). Covered by `test_prefetch_skips_bulk_when_cache_smaller_than_batch`.
- **Graceful degradation**: if either bulk call raises, the pipeline logs a warning and continues — the enrichment context just treats all senders as "new" and falls back to per-address contract age lookup if needed. Covered by `test_prefetch_continues_when_bulk_db_call_fails` / `test_prefetch_continues_when_bulk_contract_call_fails`.
- **Single-address fallback paths remain intact**: `is_new_sender_address` and `get_contract_creation_block` are still wired up and are used if `ctx` is `None` (older callers) or if the cache read misses after pre-fetch.

## Test coverage

30 new tests across 6 files; all 352 tests pass; `ruff check` clean.

- **`test_database.py`** (6): empty input, subset return, case-insensitive, dedup, chunking over 500 addresses, monitored-address scoping
- **`test_etherscan.py`** (7): empty input / single chunk / 3-chunk split / dedup / missing entries → `None` / out-of-range rejection / API error
- **`test_with_fallback.py`** (5): primary success, empty short-circuit, transport-error failover, `None`-is-authoritative (no fallback re-query), all-fail reraise
- **`test_checker.py`** (8): end-to-end "zero per-tx calls" assertion, known-sender classification, same-sender-twice semantics, cache population (hit + miss), already-cached senders skipped, cache-too-small warning + fallback, bulk-DB failure tolerance, bulk-HTTP failure tolerance
- **`test_blockscout.py` + `test_moralis.py`** (4): default loop-over-single-address implementation, dedup, empty input, per-address error swallowing

## Design doc

Full design and rationale: `docs/features/batch-spam-enrichment.md`

## Out-of-scope follow-ups

- Batched `store_transaction` via `executemany` (write path, separate cleanup)
- Migrating Moralis to its bulk `/erc20/metadata?addresses=...` endpoint (only worth it if Moralis becomes the hot path)
- Persistent on-disk contract-creation cache across restarts
- Cross-address sharing of `known_senders` pre-fetch when many monitored addresses share senders
