### PR TITLE
test: simplify test boilerplate and complexity

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -11,13 +11,28 @@ from aiogram import Bot
 from aiogram.filters.command import CommandObject
 from aiogram.types import Chat, Message, User
 
-from usdt_monitor_bot.checker import TransactionChecker
-
 # Import project components
 from usdt_monitor_bot.config import BotConfig
 from usdt_monitor_bot.database import DatabaseManager
 from usdt_monitor_bot.etherscan import EtherscanClient
 from usdt_monitor_bot.notifier import NotificationService
+
+
+def make_json_session_mock(json_data: dict, status: int = 200) -> MagicMock:
+    """Minimal mock aiohttp.ClientSession: get() returns JSON via async context manager."""
+    mock_response = AsyncMock(spec=aiohttp.ClientResponse)
+    mock_response.status = status
+    mock_response.json = AsyncMock(return_value=json_data)
+
+    mock_cm = AsyncMock()
+    mock_cm.__aenter__ = AsyncMock(return_value=mock_response)
+    mock_cm.__aexit__ = AsyncMock(return_value=None)
+
+    mock_session = MagicMock(spec=aiohttp.ClientSession)
+    mock_session.get = MagicMock(return_value=mock_cm)
+    mock_session.closed = False
+    mock_session.close = AsyncMock()
+    return mock_session
 
 
 @pytest.fixture
@@ -124,22 +139,6 @@ def mock_etherscan_client() -> AsyncMock:
 def mock_notifier() -> AsyncMock:
     """Provides a mocked NotificationService."""
     return AsyncMock(spec=NotificationService)
-
-
-@pytest.fixture
-def checker(
-    mock_config: BotConfig,
-    mock_db_manager: AsyncMock,
-    mock_etherscan_client: AsyncMock,
-    mock_notifier: AsyncMock,
-) -> TransactionChecker:
-    """Provides a TransactionChecker with mocked dependencies."""
-    return TransactionChecker(
-        config=mock_config,
-        db_manager=mock_db_manager,
-        etherscan_client=mock_etherscan_client,
-        notifier=mock_notifier,
-    )
 
 
 @pytest.fixture

--- a/tests/test_blockscout.py
+++ b/tests/test_blockscout.py
@@ -5,6 +5,7 @@ from unittest.mock import AsyncMock, MagicMock
 import aiohttp
 import pytest
 
+from tests.conftest import make_json_session_mock
 from usdt_monitor_bot.blockscout import BlockscoutClient, BlockscoutError, _normalize_tx
 
 CONTRACT = "0xdac17f958d2ee523a2206206994597c13d831ec7"
@@ -17,23 +18,6 @@ def mock_config():
     config.blockscout_base_url = "https://eth.blockscout.com/api"
     config.blockscout_api_key = None
     return config
-
-
-def _make_session(json_data: dict, status: int = 200) -> MagicMock:
-    """Build a minimal mock aiohttp session returning json_data."""
-    mock_response = AsyncMock(spec=aiohttp.ClientResponse)
-    mock_response.status = status
-    mock_response.json = AsyncMock(return_value=json_data)
-
-    mock_cm = AsyncMock()
-    mock_cm.__aenter__ = AsyncMock(return_value=mock_response)
-    mock_cm.__aexit__ = AsyncMock(return_value=None)
-
-    mock_session = MagicMock(spec=aiohttp.ClientSession)
-    mock_session.get = MagicMock(return_value=mock_cm)
-    mock_session.closed = False
-    mock_session.close = AsyncMock()
-    return mock_session
 
 
 # --- _normalize_tx ---
@@ -82,7 +66,7 @@ async def test_get_token_transactions_success(mock_config, monkeypatch):
         "tokenSymbol": "USDT",
         "tokenDecimal": "6",
     }
-    mock_session = _make_session({"status": "1", "message": "OK", "result": [sample_tx]})
+    mock_session = make_json_session_mock({"status": "1", "message": "OK", "result": [sample_tx]})
     client = BlockscoutClient(mock_config)
     client._session = mock_session
 
@@ -94,7 +78,7 @@ async def test_get_token_transactions_success(mock_config, monkeypatch):
 
 
 async def test_get_token_transactions_empty(mock_config):
-    mock_session = _make_session(
+    mock_session = make_json_session_mock(
         {"status": "0", "message": "No transactions found", "result": []}
     )
     client = BlockscoutClient(mock_config)
@@ -105,7 +89,7 @@ async def test_get_token_transactions_empty(mock_config):
 
 
 async def test_get_token_transactions_api_error(mock_config):
-    mock_session = _make_session({"status": "0", "message": "Invalid address"})
+    mock_session = make_json_session_mock({"status": "0", "message": "Invalid address"})
     client = BlockscoutClient(mock_config)
     client._session = mock_session
 
@@ -114,7 +98,7 @@ async def test_get_token_transactions_api_error(mock_config):
 
 
 async def test_get_token_transactions_http_429(mock_config):
-    mock_session = _make_session({}, status=429)
+    mock_session = make_json_session_mock({}, status=429)
     client = BlockscoutClient(mock_config)
     client._session = mock_session
 
@@ -123,7 +107,7 @@ async def test_get_token_transactions_http_429(mock_config):
 
 
 async def test_get_token_transactions_http_500(mock_config):
-    mock_session = _make_session({}, status=500)
+    mock_session = make_json_session_mock({}, status=500)
     client = BlockscoutClient(mock_config)
     client._session = mock_session
 
@@ -155,7 +139,7 @@ async def test_get_token_transactions_network_error(mock_config):
 
 
 async def test_get_latest_block_number_success(mock_config):
-    mock_session = _make_session({"result": "0x1234567"})
+    mock_session = make_json_session_mock({"result": "0x1234567"})
     client = BlockscoutClient(mock_config)
     client._session = mock_session
 
@@ -164,7 +148,7 @@ async def test_get_latest_block_number_success(mock_config):
 
 
 async def test_get_latest_block_number_returns_none_on_error_status(mock_config):
-    mock_session = _make_session({}, status=500)
+    mock_session = make_json_session_mock({}, status=500)
     client = BlockscoutClient(mock_config)
     client._session = mock_session
 
@@ -173,7 +157,7 @@ async def test_get_latest_block_number_returns_none_on_error_status(mock_config)
 
 
 async def test_get_latest_block_number_returns_none_on_rpc_error(mock_config):
-    mock_session = _make_session({"error": {"message": "rate limit"}})
+    mock_session = make_json_session_mock({"error": {"message": "rate limit"}})
     client = BlockscoutClient(mock_config)
     client._session = mock_session
 
@@ -185,7 +169,7 @@ async def test_get_latest_block_number_returns_none_on_rpc_error(mock_config):
 
 
 async def test_get_contract_creation_block_success(mock_config):
-    mock_session = _make_session({"creation_block_number": 12345678})
+    mock_session = make_json_session_mock({"creation_block_number": 12345678})
     client = BlockscoutClient(mock_config)
     client._session = mock_session
 
@@ -194,7 +178,7 @@ async def test_get_contract_creation_block_success(mock_config):
 
 
 async def test_get_contract_creation_block_missing_field(mock_config):
-    mock_session = _make_session({"some_other_field": "value"})
+    mock_session = make_json_session_mock({"some_other_field": "value"})
     client = BlockscoutClient(mock_config)
     client._session = mock_session
 
@@ -203,7 +187,7 @@ async def test_get_contract_creation_block_missing_field(mock_config):
 
 
 async def test_get_contract_creation_block_non_200(mock_config):
-    mock_session = _make_session({}, status=404)
+    mock_session = make_json_session_mock({}, status=404)
     client = BlockscoutClient(mock_config)
     client._session = mock_session
 
@@ -273,7 +257,7 @@ async def test_get_contract_creation_blocks_swallows_per_address_errors(
 
 async def test_api_key_included_in_token_tx_params(mock_config):
     mock_config.blockscout_api_key = "mykey123"
-    mock_session = _make_session({"status": "1", "message": "OK", "result": []})
+    mock_session = make_json_session_mock({"status": "1", "message": "OK", "result": []})
     client = BlockscoutClient(mock_config)
     client._session = mock_session
 
@@ -285,7 +269,7 @@ async def test_api_key_included_in_token_tx_params(mock_config):
 
 async def test_api_key_excluded_when_not_set(mock_config):
     mock_config.blockscout_api_key = None
-    mock_session = _make_session({"status": "1", "message": "OK", "result": []})
+    mock_session = make_json_session_mock({"status": "1", "message": "OK", "result": []})
     client = BlockscoutClient(mock_config)
     client._session = mock_session
 
@@ -297,7 +281,7 @@ async def test_api_key_excluded_when_not_set(mock_config):
 
 async def test_api_key_included_in_latest_block_params(mock_config):
     mock_config.blockscout_api_key = "mykey123"
-    mock_session = _make_session({"result": "0x1234567"})
+    mock_session = make_json_session_mock({"result": "0x1234567"})
     client = BlockscoutClient(mock_config)
     client._session = mock_session
 
@@ -309,7 +293,7 @@ async def test_api_key_included_in_latest_block_params(mock_config):
 
 async def test_api_key_included_in_contract_creation_params(mock_config):
     mock_config.blockscout_api_key = "mykey123"
-    mock_session = _make_session({"creation_block_number": 12345678})
+    mock_session = make_json_session_mock({"creation_block_number": 12345678})
     client = BlockscoutClient(mock_config)
     client._session = mock_session
 

--- a/tests/test_checker.py
+++ b/tests/test_checker.py
@@ -6,21 +6,16 @@ from unittest.mock import ANY, AsyncMock, MagicMock
 import pytest
 
 from usdt_monitor_bot.checker import TransactionChecker
-from usdt_monitor_bot.database import DatabaseManager
 from usdt_monitor_bot.etherscan import (
-    EtherscanClient,
     EtherscanError,
     EtherscanRateLimitError,
 )
-from usdt_monitor_bot.notifier import NotificationService
 from usdt_monitor_bot.spam_detector import SpamDetector
 from usdt_monitor_bot.transaction_parser import (
     convert_to_transaction_metadata,
     filter_transactions,
     parse_timestamp,
 )
-
-pytestmark = pytest.mark.asyncio
 
 # --- Constants ---
 ADDR1 = "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
@@ -92,66 +87,50 @@ def mock_config():
 
 
 @pytest.fixture
-def mock_db():
-    """Creates a mock DatabaseManager."""
-    return AsyncMock(spec=DatabaseManager)
-
-
-@pytest.fixture
-def mock_etherscan():
-    """Creates a mock EtherscanClient."""
-    return AsyncMock(spec=EtherscanClient)
-
-
-@pytest.fixture
-def mock_notifier():
-    """Creates a mock NotificationService."""
-    return AsyncMock(spec=NotificationService)
-
-
-@pytest.fixture
-def checker(mock_config, mock_db, mock_etherscan, mock_notifier):
+def checker(mock_config, mock_db_manager, mock_etherscan_client, mock_notifier):
     """Creates a TransactionChecker with mocked dependencies."""
-    return TransactionChecker(mock_config, mock_db, mock_etherscan, mock_notifier)
+    return TransactionChecker(
+        mock_config, mock_db_manager, mock_etherscan_client, mock_notifier
+    )
 
 
 # --- High-Level `check_all_addresses` Tests ---
 
 
-async def test_check_no_addresses(checker: TransactionChecker, mock_db: AsyncMock):
+async def test_check_no_addresses(checker: TransactionChecker, mock_db_manager: AsyncMock):
     """Test that the checker handles having no addresses to check."""
-    mock_db.get_distinct_addresses.return_value = []
+    mock_db_manager.get_distinct_addresses.return_value = []
 
     await checker.check_all_addresses()
 
-    mock_db.get_distinct_addresses.assert_awaited_once()
-    mock_db.get_last_checked_block.assert_not_awaited()
+    mock_db_manager.get_distinct_addresses.assert_awaited_once()
+    mock_db_manager.get_last_checked_block.assert_not_awaited()
 
 
 async def test_check_address_no_new_tx(
     checker: TransactionChecker,
-    mock_db: AsyncMock,
-    mock_etherscan: AsyncMock,
+    mock_db_manager: AsyncMock,
+    mock_etherscan_client: AsyncMock,
     mock_notifier: AsyncMock,
 ):
     """Test checking an address with no new transactions."""
-    mock_db.get_distinct_addresses.return_value = [ADDR1]
-    mock_db.get_last_checked_block.return_value = BLOCK_ADDR1_START
-    mock_etherscan.get_token_transactions.return_value = []
+    mock_db_manager.get_distinct_addresses.return_value = [ADDR1]
+    mock_db_manager.get_last_checked_block.return_value = BLOCK_ADDR1_START
+    mock_etherscan_client.get_token_transactions.return_value = []
     # When no transactions found, we try to get latest block to advance progress
-    mock_etherscan.get_latest_block_number.return_value = BLOCK_ADDR1_START + 100
+    mock_etherscan_client.get_latest_block_number.return_value = BLOCK_ADDR1_START + 100
 
     await checker.check_all_addresses()
 
-    mock_db.get_last_checked_block.assert_awaited_once_with(ADDR1.lower())
+    mock_db_manager.get_last_checked_block.assert_awaited_once_with(ADDR1.lower())
     # Etherscan client is called for each token (USDT, USDC)
-    assert mock_etherscan.get_token_transactions.await_count == 2
+    assert mock_etherscan_client.get_token_transactions.await_count == 2
     # When no transactions found, we try to get latest block number
-    mock_etherscan.get_latest_block_number.assert_awaited()
+    mock_etherscan_client.get_latest_block_number.assert_awaited()
     mock_notifier.send_token_notification.assert_not_awaited()
     # The block should be updated to latest block when no transactions found
     # This prevents the bot from getting stuck checking the same block repeatedly
-    mock_db.update_last_checked_block.assert_awaited_once_with(
+    mock_db_manager.update_last_checked_block.assert_awaited_once_with(
         ADDR1.lower(), BLOCK_ADDR1_START + 100
     )
 
@@ -194,24 +173,24 @@ async def test_check_single_address_with_tx(
     expected_notifications: int,
     final_block: int,
     checker: TransactionChecker,
-    mock_db: AsyncMock,
-    mock_etherscan: AsyncMock,
+    mock_db_manager: AsyncMock,
+    mock_etherscan_client: AsyncMock,
     mock_notifier: AsyncMock,
 ):
     """Test processing new transactions (incoming, outgoing, mixed) for a single address."""
     checker._spam_detection_enabled = False
-    mock_db.get_distinct_addresses.return_value = [ADDR1]
-    mock_db.get_last_checked_block.return_value = BLOCK_ADDR1_START
-    mock_db.get_users_for_address.return_value = [USER1]
+    mock_db_manager.get_distinct_addresses.return_value = [ADDR1]
+    mock_db_manager.get_last_checked_block.return_value = BLOCK_ADDR1_START
+    mock_db_manager.get_users_for_address.return_value = [USER1]
     # Assume all test transactions are for USDT
-    mock_etherscan.get_token_transactions.side_effect = [transactions, []]
+    mock_etherscan_client.get_token_transactions.side_effect = [transactions, []]
     # Mock latest block to be >= final_block to avoid reset logic
-    mock_etherscan.get_latest_block_number.return_value = final_block + 100
+    mock_etherscan_client.get_latest_block_number.return_value = final_block + 100
 
     await checker.check_all_addresses()
 
     assert mock_notifier.send_token_notification.await_count == expected_notifications
-    mock_db.update_last_checked_block.assert_awaited_once_with(
+    mock_db_manager.update_last_checked_block.assert_awaited_once_with(
         ADDR1.lower(), final_block
     )
     # Verify the last sent notification is for the last transaction
@@ -224,8 +203,8 @@ async def test_check_single_address_with_tx(
 
 async def test_check_multiple_addresses(
     checker: TransactionChecker,
-    mock_db: AsyncMock,
-    mock_etherscan: AsyncMock,
+    mock_db_manager: AsyncMock,
+    mock_etherscan_client: AsyncMock,
     mock_notifier: AsyncMock,
 ):
     """Test that multiple addresses with different tokens are processed correctly."""
@@ -233,20 +212,20 @@ async def test_check_multiple_addresses(
     tx1 = create_mock_tx(BLOCK_ADDR1_START + 1, "0xsender", ADDR1, USDT_CONTRACT)
     tx2 = create_mock_tx(BLOCK_ADDR1_START + 10, "0xsender", ADDR2, USDC_CONTRACT)
 
-    mock_db.get_distinct_addresses.return_value = [ADDR1, ADDR2]
-    mock_db.get_last_checked_block.side_effect = [
+    mock_db_manager.get_distinct_addresses.return_value = [ADDR1, ADDR2]
+    mock_db_manager.get_last_checked_block.side_effect = [
         BLOCK_ADDR1_START,
         BLOCK_ADDR1_START + 9,
     ]
-    mock_db.get_users_for_address.side_effect = [[USER1], [USER2]]
-    mock_etherscan.get_token_transactions.side_effect = [
+    mock_db_manager.get_users_for_address.side_effect = [[USER1], [USER2]]
+    mock_etherscan_client.get_token_transactions.side_effect = [
         [tx1],
         [],  # ADDR1: USDT tx, no USDC tx
         [],
         [tx2],  # ADDR2: no USDT tx, USDC tx
     ]
     # Mock latest block to be >= highest block to avoid reset logic
-    mock_etherscan.get_latest_block_number.return_value = BLOCK_ADDR1_START + 100
+    mock_etherscan_client.get_latest_block_number.return_value = BLOCK_ADDR1_START + 100
 
     await checker.check_all_addresses()
 
@@ -258,21 +237,21 @@ async def test_check_multiple_addresses(
         USER2, tx2, "USDC", ADDR2.lower(), ANY
     )
 
-    assert mock_db.update_last_checked_block.await_count == 2
-    mock_db.update_last_checked_block.assert_any_await(
+    assert mock_db_manager.update_last_checked_block.await_count == 2
+    mock_db_manager.update_last_checked_block.assert_any_await(
         ADDR1.lower(), int(tx1["blockNumber"])
     )
-    mock_db.update_last_checked_block.assert_any_await(
+    mock_db_manager.update_last_checked_block.assert_any_await(
         ADDR2.lower(), int(tx2["blockNumber"])
     )
 
 
 async def test_check_etherscan_rate_limit_skips_block_update(
-    checker: TransactionChecker, mock_db: AsyncMock, mock_etherscan: AsyncMock
+    checker: TransactionChecker, mock_db_manager: AsyncMock, mock_etherscan_client: AsyncMock
 ):
     """Test that a rate-limited address is skipped and its block is not updated."""
-    mock_db.get_distinct_addresses.return_value = [ADDR1]
-    mock_db.get_last_checked_block.return_value = BLOCK_ADDR1_START
+    mock_db_manager.get_distinct_addresses.return_value = [ADDR1]
+    mock_db_manager.get_last_checked_block.return_value = BLOCK_ADDR1_START
     # Simulate rate limit error for all token fetches for the address
     checker._fetch_transactions_for_address = AsyncMock(  # type: ignore[assignment]
         side_effect=EtherscanRateLimitError("Rate Limited")
@@ -281,13 +260,13 @@ async def test_check_etherscan_rate_limit_skips_block_update(
     await checker.check_all_addresses()
 
     # The block should not be updated for the rate-limited address.
-    mock_db.update_last_checked_block.assert_not_awaited()
+    mock_db_manager.update_last_checked_block.assert_not_awaited()
 
 
 async def test_transaction_age_filtering(
     checker: TransactionChecker,
-    mock_db: AsyncMock,
-    mock_etherscan: AsyncMock,
+    mock_db_manager: AsyncMock,
+    mock_etherscan_client: AsyncMock,
     mock_notifier: AsyncMock,
 ):
     """Test that transactions older than `max_transaction_age_days` are ignored."""
@@ -302,12 +281,12 @@ async def test_transaction_age_filtering(
         BLOCK_ADDR1_START + 2, "0xsender", ADDR1, USDT_CONTRACT, timestamp=old_ts
     )
 
-    mock_db.get_distinct_addresses.return_value = [ADDR1]
-    mock_db.get_last_checked_block.return_value = BLOCK_ADDR1_START
-    mock_db.get_users_for_address.return_value = [USER1]
-    mock_etherscan.get_token_transactions.side_effect = [[recent_tx, old_tx], []]
+    mock_db_manager.get_distinct_addresses.return_value = [ADDR1]
+    mock_db_manager.get_last_checked_block.return_value = BLOCK_ADDR1_START
+    mock_db_manager.get_users_for_address.return_value = [USER1]
+    mock_etherscan_client.get_token_transactions.side_effect = [[recent_tx, old_tx], []]
     # Mock latest block to be >= highest block to avoid reset logic
-    mock_etherscan.get_latest_block_number.return_value = BLOCK_ADDR1_START + 100
+    mock_etherscan_client.get_latest_block_number.return_value = BLOCK_ADDR1_START + 100
 
     await checker.check_all_addresses()
 
@@ -316,15 +295,15 @@ async def test_transaction_age_filtering(
         USER1, recent_tx, "USDT", ADDR1.lower(), ANY
     )
     # The block number should be updated to the highest *seen*, even if filtered
-    mock_db.update_last_checked_block.assert_awaited_once_with(
+    mock_db_manager.update_last_checked_block.assert_awaited_once_with(
         ADDR1.lower(), BLOCK_ADDR1_START + 2
     )
 
 
 async def test_transaction_count_limiting(
     checker: TransactionChecker,
-    mock_db: AsyncMock,
-    mock_etherscan: AsyncMock,
+    mock_db_manager: AsyncMock,
+    mock_etherscan_client: AsyncMock,
     mock_notifier: AsyncMock,
     mock_config: MagicMock,
 ):
@@ -337,13 +316,13 @@ async def test_transaction_count_limiting(
         for i in range(tx_count)
     ]
 
-    mock_db.get_distinct_addresses.return_value = [ADDR1]
-    mock_db.get_last_checked_block.return_value = BLOCK_ADDR1_START
-    mock_db.get_users_for_address.return_value = [USER1]
-    mock_etherscan.get_token_transactions.side_effect = [transactions, []]
+    mock_db_manager.get_distinct_addresses.return_value = [ADDR1]
+    mock_db_manager.get_last_checked_block.return_value = BLOCK_ADDR1_START
+    mock_db_manager.get_users_for_address.return_value = [USER1]
+    mock_etherscan_client.get_token_transactions.side_effect = [transactions, []]
     # Mock latest block to be >= highest block to avoid reset logic
     latest_block = BLOCK_ADDR1_START + tx_count
-    mock_etherscan.get_latest_block_number.return_value = latest_block + 100
+    mock_etherscan_client.get_latest_block_number.return_value = latest_block + 100
 
     await checker.check_all_addresses()
 
@@ -354,15 +333,15 @@ async def test_transaction_count_limiting(
     )
 
     # The latest block processed should be the newest of all transactions
-    mock_db.update_last_checked_block.assert_awaited_once_with(
+    mock_db_manager.update_last_checked_block.assert_awaited_once_with(
         ADDR1.lower(), latest_block
     )
 
 
 async def test_invalid_timestamp_is_skipped(
     checker: TransactionChecker,
-    mock_db: AsyncMock,
-    mock_etherscan: AsyncMock,
+    mock_db_manager: AsyncMock,
+    mock_etherscan_client: AsyncMock,
     mock_notifier: AsyncMock,
 ):
     """Test that a transaction with an invalid timestamp is skipped."""
@@ -371,12 +350,12 @@ async def test_invalid_timestamp_is_skipped(
     invalid_tx = create_mock_tx(BLOCK_ADDR1_START + 2, "0xsender", ADDR1, USDT_CONTRACT)
     invalid_tx["timeStamp"] = "not-a-timestamp"
 
-    mock_db.get_distinct_addresses.return_value = [ADDR1]
-    mock_db.get_last_checked_block.return_value = BLOCK_ADDR1_START
-    mock_db.get_users_for_address.return_value = [USER1]
-    mock_etherscan.get_token_transactions.side_effect = [[valid_tx, invalid_tx], []]
+    mock_db_manager.get_distinct_addresses.return_value = [ADDR1]
+    mock_db_manager.get_last_checked_block.return_value = BLOCK_ADDR1_START
+    mock_db_manager.get_users_for_address.return_value = [USER1]
+    mock_etherscan_client.get_token_transactions.side_effect = [[valid_tx, invalid_tx], []]
     # Mock latest block to be >= highest block to avoid reset logic
-    mock_etherscan.get_latest_block_number.return_value = BLOCK_ADDR1_START + 100
+    mock_etherscan_client.get_latest_block_number.return_value = BLOCK_ADDR1_START + 100
 
     await checker.check_all_addresses()
 
@@ -385,7 +364,7 @@ async def test_invalid_timestamp_is_skipped(
         USER1, valid_tx, "USDT", ADDR1.lower(), ANY
     )
     # Block should be updated to the highest block seen, even if it has invalid data and wasn't processed.
-    mock_db.update_last_checked_block.assert_awaited_once_with(
+    mock_db_manager.update_last_checked_block.assert_awaited_once_with(
         ADDR1.lower(), BLOCK_ADDR1_START + 2
     )
 
@@ -393,14 +372,13 @@ async def test_invalid_timestamp_is_skipped(
 # --- Unit Tests for Internal Methods ---
 
 
-@pytest.mark.asyncio
 async def test_fetch_transactions_success(
-    checker: TransactionChecker, mock_etherscan: AsyncMock
+    checker: TransactionChecker, mock_etherscan_client: AsyncMock
 ):
     """Test `_fetch_transactions_for_address` success case."""
     tx_usdt = create_mock_tx(1, "s", "r", USDT_CONTRACT)
     tx_usdc = create_mock_tx(2, "s", "r", USDC_CONTRACT)
-    mock_etherscan.get_token_transactions.side_effect = [[tx_usdt], [tx_usdc]]
+    mock_etherscan_client.get_token_transactions.side_effect = [[tx_usdt], [tx_usdc]]
 
     result, all_ok = await checker._fetch_transactions_for_address(ADDR1.lower(), 0)
 
@@ -408,12 +386,11 @@ async def test_fetch_transactions_success(
     assert result[0]["token_symbol"] == "USDT"
     assert result[1]["token_symbol"] == "USDC"
     assert all_ok is True
-    assert mock_etherscan.get_token_transactions.await_count == 2
+    assert mock_etherscan_client.get_token_transactions.await_count == 2
 
 
-@pytest.mark.asyncio
 async def test_fetch_transactions_partial_failure(
-    checker: TransactionChecker, mock_etherscan: AsyncMock
+    checker: TransactionChecker, mock_etherscan_client: AsyncMock
 ):
     """Test `_fetch_transactions_for_address` with one token failing.
 
@@ -421,7 +398,7 @@ async def test_fetch_transactions_partial_failure(
     all_ok flag is False so the caller knows not to advance the checkpoint.
     """
     tx_usdc = create_mock_tx(2, "s", "r", USDC_CONTRACT)
-    mock_etherscan.get_token_transactions.side_effect = [
+    mock_etherscan_client.get_token_transactions.side_effect = [
         EtherscanRateLimitError("Rate limit on USDT"),
         [tx_usdc],
     ]
@@ -435,8 +412,8 @@ async def test_fetch_transactions_partial_failure(
 
 async def test_partial_token_failure_does_not_advance_block(
     checker: TransactionChecker,
-    mock_db: AsyncMock,
-    mock_etherscan: AsyncMock,
+    mock_db_manager: AsyncMock,
+    mock_etherscan_client: AsyncMock,
     mock_notifier: AsyncMock,
 ):
     """If any token fetch fails, the address block checkpoint must NOT advance.
@@ -449,27 +426,27 @@ async def test_partial_token_failure_does_not_advance_block(
     tx_usdc = create_mock_tx(
         BLOCK_ADDR1_START + 5, "0xsender", ADDR1, USDC_CONTRACT
     )
-    mock_db.get_distinct_addresses.return_value = [ADDR1]
-    mock_db.get_last_checked_block.return_value = BLOCK_ADDR1_START
-    mock_db.get_users_for_address.return_value = [USER1]
+    mock_db_manager.get_distinct_addresses.return_value = [ADDR1]
+    mock_db_manager.get_last_checked_block.return_value = BLOCK_ADDR1_START
+    mock_db_manager.get_users_for_address.return_value = [USER1]
     # USDT fetch raises (simulating transient API failure); USDC fetch succeeds.
-    mock_etherscan.get_token_transactions.side_effect = [
+    mock_etherscan_client.get_token_transactions.side_effect = [
         EtherscanRateLimitError("USDT blew up"),
         [tx_usdc],
     ]
-    mock_etherscan.get_latest_block_number.return_value = BLOCK_ADDR1_START + 100
+    mock_etherscan_client.get_latest_block_number.return_value = BLOCK_ADDR1_START + 100
 
     await checker.check_all_addresses()
 
     # The USDC transaction may still be processed and notified,
     # but the block checkpoint must NOT advance past the failed range.
-    mock_db.update_last_checked_block.assert_not_awaited()
+    mock_db_manager.update_last_checked_block.assert_not_awaited()
 
 
 async def test_latest_block_fetched_once_per_cycle(
     checker: TransactionChecker,
-    mock_db: AsyncMock,
-    mock_etherscan: AsyncMock,
+    mock_db_manager: AsyncMock,
+    mock_etherscan_client: AsyncMock,
 ):
     """get_latest_block_number is called once per cycle, not per address.
 
@@ -478,22 +455,21 @@ async def test_latest_block_fetched_once_per_cycle(
     hoisted to check_all_addresses and reused for all addresses.
     """
     checker._spam_detection_enabled = False
-    mock_db.get_distinct_addresses.return_value = [ADDR1, ADDR2]
-    mock_db.get_last_checked_block.return_value = BLOCK_ADDR1_START
-    mock_etherscan.get_token_transactions.return_value = []
-    mock_etherscan.get_latest_block_number.return_value = BLOCK_ADDR1_START + 100
+    mock_db_manager.get_distinct_addresses.return_value = [ADDR1, ADDR2]
+    mock_db_manager.get_last_checked_block.return_value = BLOCK_ADDR1_START
+    mock_etherscan_client.get_token_transactions.return_value = []
+    mock_etherscan_client.get_latest_block_number.return_value = BLOCK_ADDR1_START + 100
 
     await checker.check_all_addresses()
 
-    assert mock_etherscan.get_latest_block_number.await_count == 1
+    assert mock_etherscan_client.get_latest_block_number.await_count == 1
 
 
 # --- Unit Tests for `_determine_next_block` ---
 
 
-@pytest.mark.asyncio
 async def test_determine_next_block_database_ahead_of_blockchain(
-    checker: TransactionChecker, mock_etherscan: AsyncMock
+    checker: TransactionChecker, mock_etherscan_client: AsyncMock
 ):
     """Test that database block ahead of blockchain is reset to latest_block."""
     start_block = 1000
@@ -501,7 +477,7 @@ async def test_determine_next_block_database_ahead_of_blockchain(
     latest_block = 995  # Blockchain is behind database
     address_lower = ADDR1.lower()
 
-    mock_etherscan.get_latest_block_number.return_value = latest_block
+    mock_etherscan_client.get_latest_block_number.return_value = latest_block
 
     result = await checker._block_tracker.determine_next_block(
         start_block, new_last_block, [], address_lower
@@ -509,12 +485,11 @@ async def test_determine_next_block_database_ahead_of_blockchain(
 
     assert result.final_block_number == latest_block
     assert result.resetting_to_latest is True
-    mock_etherscan.get_latest_block_number.assert_awaited_once()
+    mock_etherscan_client.get_latest_block_number.assert_awaited_once()
 
 
-@pytest.mark.asyncio
 async def test_determine_next_block_transaction_ahead_of_blockchain(
-    checker: TransactionChecker, mock_etherscan: AsyncMock
+    checker: TransactionChecker, mock_etherscan_client: AsyncMock
 ):
     """Test that transaction block ahead of blockchain is capped to latest_block."""
     start_block = 1000
@@ -523,7 +498,7 @@ async def test_determine_next_block_transaction_ahead_of_blockchain(
     address_lower = ADDR1.lower()
     transactions = [create_mock_tx(1010, "0xsender", ADDR1, USDT_CONTRACT)]
 
-    mock_etherscan.get_latest_block_number.return_value = latest_block
+    mock_etherscan_client.get_latest_block_number.return_value = latest_block
 
     result = await checker._block_tracker.determine_next_block(
         start_block, new_last_block, transactions, address_lower
@@ -531,12 +506,11 @@ async def test_determine_next_block_transaction_ahead_of_blockchain(
 
     assert result.final_block_number == latest_block
     assert result.resetting_to_latest is True
-    mock_etherscan.get_latest_block_number.assert_awaited_once()
+    mock_etherscan_client.get_latest_block_number.assert_awaited_once()
 
 
-@pytest.mark.asyncio
 async def test_determine_next_block_both_ahead_of_blockchain(
-    checker: TransactionChecker, mock_etherscan: AsyncMock
+    checker: TransactionChecker, mock_etherscan_client: AsyncMock
 ):
     """Test when both start_block and new_last_block are ahead of blockchain.
 
@@ -548,7 +522,7 @@ async def test_determine_next_block_both_ahead_of_blockchain(
     address_lower = ADDR1.lower()
     transactions = [create_mock_tx(1015, "0xsender", ADDR1, USDT_CONTRACT)]
 
-    mock_etherscan.get_latest_block_number.return_value = latest_block
+    mock_etherscan_client.get_latest_block_number.return_value = latest_block
 
     result = await checker._block_tracker.determine_next_block(
         start_block, new_last_block, transactions, address_lower
@@ -557,12 +531,11 @@ async def test_determine_next_block_both_ahead_of_blockchain(
     # Should reset to latest_block due to start_block check (first condition)
     assert result.final_block_number == latest_block
     assert result.resetting_to_latest is True
-    mock_etherscan.get_latest_block_number.assert_awaited_once()
+    mock_etherscan_client.get_latest_block_number.assert_awaited_once()
 
 
-@pytest.mark.asyncio
 async def test_determine_next_block_normal_case_no_reset(
-    checker: TransactionChecker, mock_etherscan: AsyncMock
+    checker: TransactionChecker, mock_etherscan_client: AsyncMock
 ):
     """Test normal case where no reset is needed."""
     start_block = 1000
@@ -571,7 +544,7 @@ async def test_determine_next_block_normal_case_no_reset(
     address_lower = ADDR1.lower()
     transactions = [create_mock_tx(1005, "0xsender", ADDR1, USDT_CONTRACT)]
 
-    mock_etherscan.get_latest_block_number.return_value = latest_block
+    mock_etherscan_client.get_latest_block_number.return_value = latest_block
 
     result = await checker._block_tracker.determine_next_block(
         start_block, new_last_block, transactions, address_lower
@@ -580,12 +553,11 @@ async def test_determine_next_block_normal_case_no_reset(
     # Should keep new_last_block as it's valid
     assert result.final_block_number == new_last_block
     assert result.resetting_to_latest is False
-    mock_etherscan.get_latest_block_number.assert_awaited_once()
+    mock_etherscan_client.get_latest_block_number.assert_awaited_once()
 
 
-@pytest.mark.asyncio
 async def test_determine_next_block_no_transactions_advances_to_latest(
-    checker: TransactionChecker, mock_etherscan: AsyncMock
+    checker: TransactionChecker, mock_etherscan_client: AsyncMock
 ):
     """Test that when no transactions found, block advances to latest_block."""
     start_block = 1000
@@ -593,7 +565,7 @@ async def test_determine_next_block_no_transactions_advances_to_latest(
     latest_block = 1005  # Blockchain has advanced
     address_lower = ADDR1.lower()
 
-    mock_etherscan.get_latest_block_number.return_value = latest_block
+    mock_etherscan_client.get_latest_block_number.return_value = latest_block
 
     result = await checker._block_tracker.determine_next_block(
         start_block, new_last_block, [], address_lower
@@ -602,19 +574,18 @@ async def test_determine_next_block_no_transactions_advances_to_latest(
     # Should advance to latest_block to prevent getting stuck
     assert result.final_block_number == latest_block
     assert result.resetting_to_latest is False
-    mock_etherscan.get_latest_block_number.assert_awaited_once()
+    mock_etherscan_client.get_latest_block_number.assert_awaited_once()
 
 
-@pytest.mark.asyncio
 async def test_determine_next_block_latest_block_none_guard_clause(
-    checker: TransactionChecker, mock_etherscan: AsyncMock
+    checker: TransactionChecker, mock_etherscan_client: AsyncMock
 ):
     """Test guard clause when latest_block cannot be fetched (returns None)."""
     start_block = 1000
     new_last_block = 1000  # No transactions
     address_lower = ADDR1.lower()
 
-    mock_etherscan.get_latest_block_number.return_value = None
+    mock_etherscan_client.get_latest_block_number.return_value = None
 
     result = await checker._block_tracker.determine_next_block(
         start_block, new_last_block, [], address_lower
@@ -623,12 +594,11 @@ async def test_determine_next_block_latest_block_none_guard_clause(
     # Should advance to query_start_block to prevent getting stuck
     assert result.final_block_number == start_block + 1
     assert result.resetting_to_latest is False
-    mock_etherscan.get_latest_block_number.assert_awaited_once()
+    mock_etherscan_client.get_latest_block_number.assert_awaited_once()
 
 
-@pytest.mark.asyncio
 async def test_determine_next_block_latest_block_none_with_transactions(
-    checker: TransactionChecker, mock_etherscan: AsyncMock
+    checker: TransactionChecker, mock_etherscan_client: AsyncMock
 ):
     """Test guard clause when latest_block is None but transactions were found."""
     start_block = 1000
@@ -636,7 +606,7 @@ async def test_determine_next_block_latest_block_none_with_transactions(
     address_lower = ADDR1.lower()
     transactions = [create_mock_tx(1005, "0xsender", ADDR1, USDT_CONTRACT)]
 
-    mock_etherscan.get_latest_block_number.return_value = None
+    mock_etherscan_client.get_latest_block_number.return_value = None
 
     result = await checker._block_tracker.determine_next_block(
         start_block, new_last_block, transactions, address_lower
@@ -645,7 +615,7 @@ async def test_determine_next_block_latest_block_none_with_transactions(
     # Should keep new_last_block since transactions were found
     assert result.final_block_number == new_last_block
     assert result.resetting_to_latest is False
-    mock_etherscan.get_latest_block_number.assert_awaited_once()
+    mock_etherscan_client.get_latest_block_number.assert_awaited_once()
 
 
 # --- Tests for Spam Detection Disabled ---
@@ -653,20 +623,20 @@ async def test_determine_next_block_latest_block_none_with_transactions(
 
 async def test_spam_detection_disabled(
     mock_config: MagicMock,
-    mock_db: AsyncMock,
-    mock_etherscan: AsyncMock,
+    mock_db_manager: AsyncMock,
+    mock_etherscan_client: AsyncMock,
     mock_notifier: AsyncMock,
 ):
     """Test that spam detection can be disabled."""
-    checker = TransactionChecker(mock_config, mock_db, mock_etherscan, mock_notifier)
+    checker = TransactionChecker(mock_config, mock_db_manager, mock_etherscan_client, mock_notifier)
     checker._spam_detection_enabled = False
 
     tx = create_mock_tx(BLOCK_ADDR1_START + 1, "0xsender", ADDR1, USDT_CONTRACT)
-    mock_db.get_distinct_addresses.return_value = [ADDR1]
-    mock_db.get_last_checked_block.return_value = BLOCK_ADDR1_START
-    mock_db.get_users_for_address.return_value = [USER1]
-    mock_etherscan.get_token_transactions.side_effect = [[tx], []]
-    mock_etherscan.get_latest_block_number.return_value = BLOCK_ADDR1_START + 100
+    mock_db_manager.get_distinct_addresses.return_value = [ADDR1]
+    mock_db_manager.get_last_checked_block.return_value = BLOCK_ADDR1_START
+    mock_db_manager.get_users_for_address.return_value = [USER1]
+    mock_etherscan_client.get_token_transactions.side_effect = [[tx], []]
+    mock_etherscan_client.get_latest_block_number.return_value = BLOCK_ADDR1_START + 100
 
     await checker.check_all_addresses()
 
@@ -679,14 +649,14 @@ async def test_spam_detection_disabled(
 
 async def test_spam_detection_with_custom_detector(
     mock_config: MagicMock,
-    mock_db: AsyncMock,
-    mock_etherscan: AsyncMock,
+    mock_db_manager: AsyncMock,
+    mock_etherscan_client: AsyncMock,
     mock_notifier: AsyncMock,
 ):
     """Test that custom spam detector can be injected."""
     custom_detector = SpamDetector(config={"suspicious_score_threshold": 100})
     checker = TransactionChecker(
-        mock_config, mock_db, mock_etherscan, mock_notifier, spam_detector=custom_detector
+        mock_config, mock_db_manager, mock_etherscan_client, mock_notifier, spam_detector=custom_detector
     )
 
     assert checker._spam_detector is custom_detector
@@ -852,18 +822,18 @@ async def test_filter_transactions_excludes_at_or_below_start_block():
 
 async def test_transactions_found_but_no_users_tracking(
     checker: TransactionChecker,
-    mock_db: AsyncMock,
-    mock_etherscan: AsyncMock,
+    mock_db_manager: AsyncMock,
+    mock_etherscan_client: AsyncMock,
     mock_notifier: AsyncMock,
     caplog,
 ):
     """Test behavior when transactions are found but no users track the address."""
     tx = create_mock_tx(BLOCK_ADDR1_START + 1, "0xsender", ADDR1, USDT_CONTRACT)
-    mock_db.get_distinct_addresses.return_value = [ADDR1]
-    mock_db.get_last_checked_block.return_value = BLOCK_ADDR1_START
-    mock_db.get_users_for_address.return_value = []  # No users tracking
-    mock_etherscan.get_token_transactions.side_effect = [[tx], []]
-    mock_etherscan.get_latest_block_number.return_value = BLOCK_ADDR1_START + 100
+    mock_db_manager.get_distinct_addresses.return_value = [ADDR1]
+    mock_db_manager.get_last_checked_block.return_value = BLOCK_ADDR1_START
+    mock_db_manager.get_users_for_address.return_value = []  # No users tracking
+    mock_etherscan_client.get_token_transactions.side_effect = [[tx], []]
+    mock_etherscan_client.get_latest_block_number.return_value = BLOCK_ADDR1_START + 100
 
     with caplog.at_level(logging.DEBUG):
         await checker.check_all_addresses()
@@ -879,12 +849,12 @@ async def test_transactions_found_but_no_users_tracking(
 
 async def test_process_transaction_missing_hash_or_symbol(
     checker: TransactionChecker,
-    mock_db: AsyncMock,
+    mock_db_manager: AsyncMock,
     mock_notifier: AsyncMock,
     caplog,
 ):
     """Test that transactions missing hash or symbol are skipped."""
-    mock_db.get_recent_transactions.return_value = []
+    mock_db_manager.get_recent_transactions.return_value = []
 
     with caplog.at_level(logging.WARNING):
         # Missing hash
@@ -907,13 +877,13 @@ async def test_process_transaction_missing_hash_or_symbol(
 
 async def test_in_batch_dedup_same_tx_hash_one_notification_per_user(
     checker: TransactionChecker,
-    mock_db: AsyncMock,
+    mock_db_manager: AsyncMock,
     mock_notifier: AsyncMock,
 ):
     """Same tx_hash appearing twice in batch (e.g. USDT + USDC) yields one notification per user."""
     checker._spam_detection_enabled = False
-    mock_db.get_recent_transactions.return_value = []
-    mock_db.get_users_for_address.return_value = [USER1]
+    mock_db_manager.get_recent_transactions.return_value = []
+    mock_db_manager.get_users_for_address.return_value = [USER1]
 
     same_hash = "0xabcd1234"
     tx_usdt = create_mock_tx(
@@ -942,12 +912,12 @@ async def test_in_batch_dedup_same_tx_hash_one_notification_per_user(
 
 async def test_notification_cache_skips_duplicate_send(
     checker: TransactionChecker,
-    mock_db: AsyncMock,
+    mock_db_manager: AsyncMock,
     mock_notifier: AsyncMock,
 ):
     """Same (user_id, tx_hash) sent again in same checker instance is skipped (cache hit)."""
     checker._spam_detection_enabled = False
-    mock_db.get_recent_transactions.return_value = []
+    mock_db_manager.get_recent_transactions.return_value = []
 
     tx = create_mock_tx(
         BLOCK_ADDR1_START + 1, "0xsender", ADDR1, USDT_CONTRACT, tx_hash="0xunique99"
@@ -970,15 +940,15 @@ async def test_notification_cache_skips_duplicate_send(
 
 async def test_notification_cache_disabled_when_size_zero(
     mock_config: MagicMock,
-    mock_db: AsyncMock,
-    mock_etherscan: AsyncMock,
+    mock_db_manager: AsyncMock,
+    mock_etherscan_client: AsyncMock,
     mock_notifier: AsyncMock,
 ):
     """When notification_dedup_cache_size is 0, cache is disabled; duplicate sends are not suppressed."""
     mock_config.notification_dedup_cache_size = 0
-    checker = TransactionChecker(mock_config, mock_db, mock_etherscan, mock_notifier)
+    checker = TransactionChecker(mock_config, mock_db_manager, mock_etherscan_client, mock_notifier)
     checker._spam_detection_enabled = False
-    mock_db.get_recent_transactions.return_value = []
+    mock_db_manager.get_recent_transactions.return_value = []
 
     tx = create_mock_tx(
         BLOCK_ADDR1_START + 1, "0xsender", ADDR1, USDT_CONTRACT, tx_hash="0xdup"
@@ -1001,14 +971,14 @@ async def test_notification_cache_disabled_when_size_zero(
 
 async def test_contract_age_blocks_caching(
     checker: TransactionChecker,
-    mock_etherscan: AsyncMock,
+    mock_etherscan_client: AsyncMock,
 ):
     """Test that contract creation blocks are cached."""
     contract_address = "0xcontract123"
     current_block = 1000
     creation_block = 500
 
-    mock_etherscan.get_contract_creation_block.return_value = creation_block
+    mock_etherscan_client.get_contract_creation_block.return_value = creation_block
 
     # First call - should fetch from Etherscan
     age1 = await checker._get_contract_age_blocks(contract_address, current_block)
@@ -1019,17 +989,17 @@ async def test_contract_age_blocks_caching(
     assert age2 == 600  # 1100 - 500
 
     # Etherscan should only be called once
-    mock_etherscan.get_contract_creation_block.assert_awaited_once()
+    mock_etherscan_client.get_contract_creation_block.assert_awaited_once()
 
 
 async def test_contract_age_blocks_error_cached_as_none(
     checker: TransactionChecker,
-    mock_etherscan: AsyncMock,
+    mock_etherscan_client: AsyncMock,
 ):
     """Test that errors are cached to avoid repeated failed calls."""
     contract_address = "0xcontract456"
 
-    mock_etherscan.get_contract_creation_block.side_effect = Exception("API Error")
+    mock_etherscan_client.get_contract_creation_block.side_effect = Exception("API Error")
 
     # First call - should attempt fetch and fail
     age1 = await checker._get_contract_age_blocks(contract_address, 1000)
@@ -1040,7 +1010,7 @@ async def test_contract_age_blocks_error_cached_as_none(
     assert age2 == 0
 
     # Etherscan should only be called once
-    mock_etherscan.get_contract_creation_block.assert_awaited_once()
+    mock_etherscan_client.get_contract_creation_block.assert_awaited_once()
 
 
 async def test_contract_creation_cache_lru_eviction(
@@ -1150,7 +1120,7 @@ def test_add_notification_sent_disabled_when_max_size_zero(checker: TransactionC
 
 async def test_process_unknown_token_returns_zero(
     checker: TransactionChecker,
-    mock_db: AsyncMock,
+    mock_db_manager: AsyncMock,
     mock_notifier: AsyncMock,
 ):
     """_process_single_transaction returns 0 immediately for unknown token symbol."""
@@ -1170,7 +1140,7 @@ async def test_process_unknown_token_returns_zero(
 
     assert result == 0
     mock_notifier.send_token_notification.assert_not_awaited()
-    mock_db.store_transaction.assert_not_awaited()
+    mock_db_manager.store_transaction.assert_not_awaited()
 
 
 # --- Batch spam-enrichment pre-fetch tests ---
@@ -1178,8 +1148,8 @@ async def test_process_unknown_token_returns_zero(
 
 async def test_prefetch_eliminates_per_tx_sender_and_contract_calls(
     checker: TransactionChecker,
-    mock_db: AsyncMock,
-    mock_etherscan: AsyncMock,
+    mock_db_manager: AsyncMock,
+    mock_etherscan_client: AsyncMock,
     mock_notifier: AsyncMock,
 ):
     """
@@ -1187,12 +1157,12 @@ async def test_prefetch_eliminates_per_tx_sender_and_contract_calls(
     the checker makes exactly 1 bulk DB call and 1 bulk contract-creation call,
     and **zero** single-address fallback calls.
     """
-    mock_db.get_recent_transactions.return_value = []
-    mock_db.get_users_for_address.return_value = [USER1]
+    mock_db_manager.get_recent_transactions.return_value = []
+    mock_db_manager.get_users_for_address.return_value = [USER1]
     # Batch mode is controlled by the presence of the bulk methods; make them
     # return deterministic data so we can assert over the per-tx path.
-    mock_db.get_known_senders.return_value = set()
-    mock_etherscan.get_contract_creation_blocks.return_value = {
+    mock_db_manager.get_known_senders.return_value = set()
+    mock_etherscan_client.get_contract_creation_blocks.return_value = {
         "0xsender0000000000000000000000000000000001": 100,
         "0xsender0000000000000000000000000000000002": 200,
         "0xsender0000000000000000000000000000000003": 300,
@@ -1220,19 +1190,19 @@ async def test_prefetch_eliminates_per_tx_sender_and_contract_calls(
     )
 
     # Exactly one bulk DB call for known senders
-    mock_db.get_known_senders.assert_awaited_once()
-    bulk_args = mock_db.get_known_senders.await_args
+    mock_db_manager.get_known_senders.assert_awaited_once()
+    bulk_args = mock_db_manager.get_known_senders.await_args
     assert bulk_args.args[0] == ADDR1.lower()
     assert set(bulk_args.args[1]) == set(senders)
 
     # Exactly one bulk contract-creation call
-    mock_etherscan.get_contract_creation_blocks.assert_awaited_once()
-    creation_args = mock_etherscan.get_contract_creation_blocks.await_args
+    mock_etherscan_client.get_contract_creation_blocks.assert_awaited_once()
+    creation_args = mock_etherscan_client.get_contract_creation_blocks.await_args
     assert set(creation_args.args[0]) == set(senders)
 
     # Per-tx fallback paths must NOT have been hit
-    mock_db.is_new_sender_address.assert_not_awaited()
-    mock_etherscan.get_contract_creation_block.assert_not_awaited()
+    mock_db_manager.is_new_sender_address.assert_not_awaited()
+    mock_etherscan_client.get_contract_creation_block.assert_not_awaited()
 
     # And a notification was sent for each tx
     assert mock_notifier.send_token_notification.await_count == 3
@@ -1240,19 +1210,19 @@ async def test_prefetch_eliminates_per_tx_sender_and_contract_calls(
 
 async def test_prefetch_marks_all_senders_known_as_not_new(
     checker: TransactionChecker,
-    mock_db: AsyncMock,
-    mock_etherscan: AsyncMock,
+    mock_db_manager: AsyncMock,
+    mock_etherscan_client: AsyncMock,
     mock_notifier: AsyncMock,
 ):
     """When every sender is already known, none of the txs should be flagged as new."""
-    mock_db.get_recent_transactions.return_value = []
-    mock_db.get_users_for_address.return_value = [USER1]
+    mock_db_manager.get_recent_transactions.return_value = []
+    mock_db_manager.get_users_for_address.return_value = [USER1]
     # Disable contract-age lookup noise by returning all None.
-    mock_etherscan.get_contract_creation_blocks.return_value = {}
+    mock_etherscan_client.get_contract_creation_blocks.return_value = {}
 
     sender = "0xsender0000000000000000000000000000000099"
     # Bulk DB reports the sender as known.
-    mock_db.get_known_senders.return_value = {sender}
+    mock_db_manager.get_known_senders.return_value = {sender}
 
     tx = create_mock_tx(
         BLOCK_ADDR1_START + 1, sender, ADDR1, USDT_CONTRACT, tx_hash="0xknown01"
@@ -1274,23 +1244,23 @@ async def test_prefetch_marks_all_senders_known_as_not_new(
     )
 
     assert captured["is_new_address"] is False
-    mock_db.is_new_sender_address.assert_not_awaited()
+    mock_db_manager.is_new_sender_address.assert_not_awaited()
 
 
 async def test_prefetch_same_sender_twice_second_is_not_new(
     checker: TransactionChecker,
-    mock_db: AsyncMock,
-    mock_etherscan: AsyncMock,
+    mock_db_manager: AsyncMock,
+    mock_etherscan_client: AsyncMock,
 ):
     """
     If the same sender appears twice in a batch, the first tx should see it as
     new and the second as known — matching pre-batching semantics, where
     store_transaction() mid-loop would flip the DB state between iterations.
     """
-    mock_db.get_recent_transactions.return_value = []
-    mock_db.get_users_for_address.return_value = [USER1]
-    mock_db.get_known_senders.return_value = set()
-    mock_etherscan.get_contract_creation_blocks.return_value = {}
+    mock_db_manager.get_recent_transactions.return_value = []
+    mock_db_manager.get_users_for_address.return_value = [USER1]
+    mock_db_manager.get_known_senders.return_value = set()
+    mock_etherscan_client.get_contract_creation_blocks.return_value = {}
 
     sender = "0xsender00000000000000000000000000000000ab"
     tx1 = create_mock_tx(
@@ -1321,17 +1291,17 @@ async def test_prefetch_same_sender_twice_second_is_not_new(
 
 async def test_prefetch_populates_contract_creation_cache(
     checker: TransactionChecker,
-    mock_db: AsyncMock,
-    mock_etherscan: AsyncMock,
+    mock_db_manager: AsyncMock,
+    mock_etherscan_client: AsyncMock,
 ):
     """Bulk pre-fetch populates _contract_creation_cache with both hits and misses."""
-    mock_db.get_recent_transactions.return_value = []
-    mock_db.get_users_for_address.return_value = [USER1]
-    mock_db.get_known_senders.return_value = set()
+    mock_db_manager.get_recent_transactions.return_value = []
+    mock_db_manager.get_users_for_address.return_value = [USER1]
+    mock_db_manager.get_known_senders.return_value = set()
 
     hit_sender = "0xsender0000000000000000000000000000000501"
     miss_sender = "0xsender0000000000000000000000000000000502"
-    mock_etherscan.get_contract_creation_blocks.return_value = {
+    mock_etherscan_client.get_contract_creation_blocks.return_value = {
         hit_sender: 12345,
         # miss_sender intentionally absent; checker should cache it as None.
     }
@@ -1353,19 +1323,19 @@ async def test_prefetch_populates_contract_creation_cache(
     assert checker._contract_creation_cache[miss_sender] is None
 
     # Single-address fallback must not have been invoked at any point.
-    mock_etherscan.get_contract_creation_block.assert_not_awaited()
+    mock_etherscan_client.get_contract_creation_block.assert_not_awaited()
 
 
 async def test_prefetch_skips_already_cached_senders(
     checker: TransactionChecker,
-    mock_db: AsyncMock,
-    mock_etherscan: AsyncMock,
+    mock_db_manager: AsyncMock,
+    mock_etherscan_client: AsyncMock,
 ):
     """Senders already in _contract_creation_cache are not re-queried in bulk."""
-    mock_db.get_recent_transactions.return_value = []
-    mock_db.get_users_for_address.return_value = [USER1]
-    mock_db.get_known_senders.return_value = set()
-    mock_etherscan.get_contract_creation_blocks.return_value = {}
+    mock_db_manager.get_recent_transactions.return_value = []
+    mock_db_manager.get_users_for_address.return_value = [USER1]
+    mock_db_manager.get_known_senders.return_value = set()
+    mock_etherscan_client.get_contract_creation_blocks.return_value = {}
 
     cached_sender = "0xsender00000000000000000000000000000006cc"
     fresh_sender = "0xsender00000000000000000000000000000006ff"
@@ -1385,26 +1355,26 @@ async def test_prefetch_skips_already_cached_senders(
         [USER1], batch, ADDR1.lower()
     )
 
-    mock_etherscan.get_contract_creation_blocks.assert_awaited_once()
-    requested = mock_etherscan.get_contract_creation_blocks.await_args.args[0]
+    mock_etherscan_client.get_contract_creation_blocks.assert_awaited_once()
+    requested = mock_etherscan_client.get_contract_creation_blocks.await_args.args[0]
     assert cached_sender not in requested
     assert fresh_sender in requested
 
 
 async def test_prefetch_skips_bulk_when_cache_smaller_than_batch(
     checker: TransactionChecker,
-    mock_db: AsyncMock,
-    mock_etherscan: AsyncMock,
+    mock_db_manager: AsyncMock,
+    mock_etherscan_client: AsyncMock,
     caplog,
 ):
     """
     If _contract_creation_cache_max_size < unique senders, pre-fetch is skipped
     and the per-tx fallback path is used instead, with a warning logged.
     """
-    mock_db.get_recent_transactions.return_value = []
-    mock_db.get_users_for_address.return_value = [USER1]
-    mock_db.get_known_senders.return_value = set()
-    mock_etherscan.get_contract_creation_block.return_value = None
+    mock_db_manager.get_recent_transactions.return_value = []
+    mock_db_manager.get_users_for_address.return_value = [USER1]
+    mock_db_manager.get_known_senders.return_value = set()
+    mock_etherscan_client.get_contract_creation_block.return_value = None
 
     # Squeeze the cache so pre-fetch would overflow it.
     checker._contract_creation_cache_max_size = 1
@@ -1429,15 +1399,15 @@ async def test_prefetch_skips_bulk_when_cache_smaller_than_batch(
         )
 
     # Bulk path must be skipped...
-    mock_etherscan.get_contract_creation_blocks.assert_not_awaited()
+    mock_etherscan_client.get_contract_creation_blocks.assert_not_awaited()
     # ...and a warning emitted.
     assert any("contract_creation_cache_size" in r.message for r in caplog.records)
 
 
 async def test_prefetch_continues_when_bulk_db_call_fails(
     checker: TransactionChecker,
-    mock_db: AsyncMock,
-    mock_etherscan: AsyncMock,
+    mock_db_manager: AsyncMock,
+    mock_etherscan_client: AsyncMock,
     mock_notifier: AsyncMock,
     caplog,
 ):
@@ -1445,10 +1415,10 @@ async def test_prefetch_continues_when_bulk_db_call_fails(
     # Spam detection off so we don't couple this test to scoring details;
     # the point is the pipeline survives a bulk-DB failure without crashing.
     checker._spam_detection_enabled = False
-    mock_db.get_recent_transactions.return_value = []
-    mock_db.get_users_for_address.return_value = [USER1]
-    mock_db.get_known_senders.side_effect = Exception("boom")
-    mock_etherscan.get_contract_creation_blocks.return_value = {}
+    mock_db_manager.get_recent_transactions.return_value = []
+    mock_db_manager.get_users_for_address.return_value = [USER1]
+    mock_db_manager.get_known_senders.side_effect = Exception("boom")
+    mock_etherscan_client.get_contract_creation_blocks.return_value = {}
 
     tx = create_mock_tx(
         BLOCK_ADDR1_START + 1,
@@ -1468,26 +1438,26 @@ async def test_prefetch_continues_when_bulk_db_call_fails(
     mock_notifier.send_token_notification.assert_awaited_once()
     # Single-address DB fallback must NOT be used — the enrichment context
     # just treats every sender as "new" when the bulk call fails.
-    mock_db.is_new_sender_address.assert_not_awaited()
+    mock_db_manager.is_new_sender_address.assert_not_awaited()
     assert any("Bulk known-senders" in r.message for r in caplog.records)
 
 
 async def test_prefetch_continues_when_bulk_contract_call_fails(
     checker: TransactionChecker,
-    mock_db: AsyncMock,
-    mock_etherscan: AsyncMock,
+    mock_db_manager: AsyncMock,
+    mock_etherscan_client: AsyncMock,
     mock_notifier: AsyncMock,
     caplog,
 ):
     """If get_contract_creation_blocks raises, pre-fetch logs and keeps running."""
     checker._spam_detection_enabled = False
-    mock_db.get_recent_transactions.return_value = []
-    mock_db.get_users_for_address.return_value = [USER1]
-    mock_db.get_known_senders.return_value = set()
-    mock_etherscan.get_contract_creation_blocks.side_effect = Exception(
+    mock_db_manager.get_recent_transactions.return_value = []
+    mock_db_manager.get_users_for_address.return_value = [USER1]
+    mock_db_manager.get_known_senders.return_value = set()
+    mock_etherscan_client.get_contract_creation_blocks.side_effect = Exception(
         "transport dead"
     )
-    mock_etherscan.get_contract_creation_block.return_value = None
+    mock_etherscan_client.get_contract_creation_block.return_value = None
 
     sender = "0xsender0000000000000000000000000000000901"
     tx = create_mock_tx(

--- a/tests/test_etherscan.py
+++ b/tests/test_etherscan.py
@@ -13,9 +13,6 @@ from usdt_monitor_bot.etherscan import (
     EtherscanRateLimitError,
 )
 
-pytestmark = pytest.mark.asyncio
-
-
 # Test data
 ADDR1 = "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
 BLOCK_START = 1000
@@ -99,7 +96,6 @@ async def etherscan_client_with_mocked_session(
     # __aexit__ will call mock_aiohttp_session.close()
 
 
-@pytest.mark.asyncio
 async def test_get_token_transactions_success(
     etherscan_client_with_mocked_session, mock_aiohttp_session
 ):
@@ -133,7 +129,6 @@ async def test_get_token_transactions_success(
     assert mock_session_get.call_count == 1
 
 
-@pytest.mark.asyncio
 async def test_get_token_transactions_empty(
     etherscan_client_with_mocked_session, mock_aiohttp_session
 ):
@@ -156,7 +151,6 @@ async def test_get_token_transactions_empty(
     assert mock_session_get.call_count == 1
 
 
-@pytest.mark.asyncio
 async def test_get_token_transactions_rate_limit_eventually_fails(
     etherscan_client_with_mocked_session, mock_aiohttp_session
 ):
@@ -202,7 +196,6 @@ async def test_get_token_transactions_rate_limit_eventually_fails(
     )  # Tenacity default attempts for the client
 
 
-@pytest.mark.asyncio
 async def test_get_token_transactions_api_error_no_retry(
     etherscan_client_with_mocked_session, mock_aiohttp_session
 ):
@@ -229,7 +222,6 @@ async def test_get_token_transactions_api_error_no_retry(
     assert mock_session_get.call_count == 1  # Should not retry this
 
 
-@pytest.mark.asyncio
 async def test_get_token_transactions_notok_error(
     etherscan_client_with_mocked_session, mock_aiohttp_session
 ):
@@ -262,7 +254,6 @@ async def test_get_token_transactions_notok_error(
     assert mock_session_get.call_count == 1
 
 
-@pytest.mark.asyncio
 async def test_get_token_transactions_http_error_retried(
     etherscan_client_with_mocked_session, mock_aiohttp_session
 ):
@@ -282,7 +273,6 @@ async def test_get_token_transactions_http_error_retried(
     assert mock_session_get.call_count == 5
 
 
-@pytest.mark.asyncio
 async def test_get_token_transactions_timeout_retried(
     etherscan_client_with_mocked_session, mock_aiohttp_session
 ):
@@ -302,7 +292,6 @@ async def test_get_token_transactions_timeout_retried(
     assert mock_session_get.call_count == 5
 
 
-@pytest.mark.asyncio
 async def test_get_token_transactions_unexpected_format_no_retry(
     etherscan_client_with_mocked_session, mock_aiohttp_session
 ):
@@ -325,7 +314,6 @@ async def test_get_token_transactions_unexpected_format_no_retry(
     assert mock_session_get.call_count == 1
 
 
-@pytest.mark.asyncio
 async def test_retry_success_on_third_attempt_rate_limit(
     etherscan_client_with_mocked_session, mock_aiohttp_session
 ):
@@ -368,7 +356,6 @@ async def test_retry_success_on_third_attempt_rate_limit(
     assert result[0]["tx_id"] == "success"
 
 
-@pytest.mark.asyncio
 async def test_retry_success_on_client_error(
     etherscan_client_with_mocked_session, mock_aiohttp_session
 ):
@@ -401,7 +388,6 @@ async def test_retry_success_on_client_error(
     assert result[0]["tx_id"] == "net_success"
 
 
-@pytest.mark.asyncio
 async def test_get_latest_block_number_rate_limit_in_result(
     etherscan_client_with_mocked_session, mock_aiohttp_session
 ):
@@ -420,7 +406,6 @@ async def test_get_latest_block_number_rate_limit_in_result(
     assert "rate limit" in str(exc_info.value).lower()
 
 
-@pytest.mark.asyncio
 async def test_get_latest_block_number_success(
     etherscan_client_with_mocked_session, mock_aiohttp_session
 ):
@@ -439,7 +424,6 @@ async def test_get_latest_block_number_success(
     assert mock_session_get.call_count == 1
 
 
-@pytest.mark.asyncio
 async def test_get_latest_block_number_invalid_hex(
     etherscan_client_with_mocked_session, mock_aiohttp_session
 ):
@@ -458,7 +442,6 @@ async def test_get_latest_block_number_invalid_hex(
     assert mock_session_get.call_count == 1
 
 
-@pytest.mark.asyncio
 async def test_client_session_cleanup(mock_config, mock_aiohttp_session, monkeypatch):
     """Test that the client session is properly cleaned up."""
     # Patch aiohttp.ClientSession globally for this test to ensure our mock is used
@@ -583,7 +566,6 @@ def test_rate_limiter_does_not_reduce_below_min_delay():
 # --- _MAX_VALID_BLOCK_NUMBER validation ---
 
 
-@pytest.mark.asyncio
 async def test_get_latest_block_number_rejects_out_of_range(
     etherscan_client_with_mocked_session, mock_aiohttp_session
 ):
@@ -601,7 +583,6 @@ async def test_get_latest_block_number_rejects_out_of_range(
     assert result is None
 
 
-@pytest.mark.asyncio
 async def test_get_latest_block_number_accepts_valid_block(
     etherscan_client_with_mocked_session, mock_aiohttp_session
 ):
@@ -615,7 +596,6 @@ async def test_get_latest_block_number_accepts_valid_block(
     assert result == valid_block
 
 
-@pytest.mark.asyncio
 async def test_get_contract_creation_block_rejects_out_of_range(
     etherscan_client_with_mocked_session, mock_aiohttp_session
 ):
@@ -633,7 +613,6 @@ async def test_get_contract_creation_block_rejects_out_of_range(
     assert result is None
 
 
-@pytest.mark.asyncio
 async def test_get_contract_creation_block_accepts_valid_block(
     etherscan_client_with_mocked_session, mock_aiohttp_session
 ):
@@ -654,7 +633,6 @@ async def test_get_contract_creation_block_accepts_valid_block(
 # --- Batch contract creation tests ---
 
 
-@pytest.mark.asyncio
 async def test_get_contract_creation_blocks_empty_input(
     etherscan_client_with_mocked_session, mock_aiohttp_session
 ):
@@ -666,7 +644,6 @@ async def test_get_contract_creation_blocks_empty_input(
     mock_aiohttp_session.get.assert_not_called()
 
 
-@pytest.mark.asyncio
 async def test_get_contract_creation_blocks_single_chunk(
     etherscan_client_with_mocked_session, mock_aiohttp_session
 ):
@@ -706,7 +683,6 @@ async def test_get_contract_creation_blocks_single_chunk(
     assert set(csv.split(",")) == {a.lower() for a in addrs}
 
 
-@pytest.mark.asyncio
 async def test_get_contract_creation_blocks_chunks_by_5(
     etherscan_client_with_mocked_session, mock_aiohttp_session
 ):
@@ -729,7 +705,6 @@ async def test_get_contract_creation_blocks_chunks_by_5(
     assert all(v is None for v in result.values())
 
 
-@pytest.mark.asyncio
 async def test_get_contract_creation_blocks_deduplicates_input(
     etherscan_client_with_mocked_session, mock_aiohttp_session
 ):
@@ -754,7 +729,6 @@ async def test_get_contract_creation_blocks_deduplicates_input(
     assert mock_aiohttp_session.get.call_count == 1
 
 
-@pytest.mark.asyncio
 async def test_get_contract_creation_blocks_missing_entries_are_none(
     etherscan_client_with_mocked_session, mock_aiohttp_session
 ):
@@ -783,7 +757,6 @@ async def test_get_contract_creation_blocks_missing_entries_are_none(
     assert result == {addrs[0]: 1, addrs[1]: None, addrs[2]: 3}
 
 
-@pytest.mark.asyncio
 async def test_get_contract_creation_blocks_rejects_out_of_range(
     etherscan_client_with_mocked_session, mock_aiohttp_session
 ):
@@ -811,7 +784,6 @@ async def test_get_contract_creation_blocks_rejects_out_of_range(
     assert result[addrs[1]] is None
 
 
-@pytest.mark.asyncio
 async def test_get_contract_creation_blocks_api_error_returns_empty(
     etherscan_client_with_mocked_session, mock_aiohttp_session
 ):

--- a/tests/test_moralis.py
+++ b/tests/test_moralis.py
@@ -5,6 +5,7 @@ from unittest.mock import AsyncMock, MagicMock
 import aiohttp
 import pytest
 
+from tests.conftest import make_json_session_mock
 from usdt_monitor_bot.moralis import MoralisClient, MoralisError, _normalize_tx
 
 CONTRACT = "0xdac17f958d2ee523a2206206994597c13d831ec7"
@@ -29,22 +30,6 @@ def mock_config():
     config = MagicMock()
     config.moralis_api_key = "test_moralis_key"
     return config
-
-
-def _make_session(json_data: dict, status: int = 200) -> MagicMock:
-    mock_response = AsyncMock(spec=aiohttp.ClientResponse)
-    mock_response.status = status
-    mock_response.json = AsyncMock(return_value=json_data)
-
-    mock_cm = AsyncMock()
-    mock_cm.__aenter__ = AsyncMock(return_value=mock_response)
-    mock_cm.__aexit__ = AsyncMock(return_value=None)
-
-    mock_session = MagicMock(spec=aiohttp.ClientSession)
-    mock_session.get = MagicMock(return_value=mock_cm)
-    mock_session.closed = False
-    mock_session.close = AsyncMock()
-    return mock_session
 
 
 # --- _normalize_tx ---
@@ -91,7 +76,7 @@ def test_normalize_tx_missing_fields():
 
 
 async def test_get_token_transactions_success(mock_config):
-    mock_session = _make_session({"result": [SAMPLE_MORALIS_TX], "cursor": None})
+    mock_session = make_json_session_mock({"result": [SAMPLE_MORALIS_TX], "cursor": None})
     client = MoralisClient(mock_config)
     client._session = mock_session
 
@@ -103,7 +88,7 @@ async def test_get_token_transactions_success(mock_config):
 
 
 async def test_get_token_transactions_empty(mock_config):
-    mock_session = _make_session({"result": [], "cursor": None})
+    mock_session = make_json_session_mock({"result": [], "cursor": None})
     client = MoralisClient(mock_config)
     client._session = mock_session
 
@@ -112,7 +97,7 @@ async def test_get_token_transactions_empty(mock_config):
 
 
 async def test_get_token_transactions_401_raises(mock_config):
-    mock_session = _make_session({"message": "Invalid API key"}, status=401)
+    mock_session = make_json_session_mock({"message": "Invalid API key"}, status=401)
     client = MoralisClient(mock_config)
     client._session = mock_session
 
@@ -121,7 +106,7 @@ async def test_get_token_transactions_401_raises(mock_config):
 
 
 async def test_get_token_transactions_429_raises(mock_config):
-    mock_session = _make_session({}, status=429)
+    mock_session = make_json_session_mock({}, status=429)
     client = MoralisClient(mock_config)
     client._session = mock_session
 
@@ -130,7 +115,7 @@ async def test_get_token_transactions_429_raises(mock_config):
 
 
 async def test_get_token_transactions_500_raises(mock_config):
-    mock_session = _make_session({}, status=500)
+    mock_session = make_json_session_mock({}, status=500)
     client = MoralisClient(mock_config)
     client._session = mock_session
 
@@ -139,7 +124,7 @@ async def test_get_token_transactions_500_raises(mock_config):
 
 
 async def test_get_token_transactions_with_start_block(mock_config):
-    mock_session = _make_session({"result": []})
+    mock_session = make_json_session_mock({"result": []})
     client = MoralisClient(mock_config)
     client._session = mock_session
 
@@ -156,7 +141,7 @@ async def test_get_token_transactions_with_start_block(mock_config):
 
 
 async def test_get_latest_block_number_success(mock_config):
-    mock_session = _make_session({"block": 19000000, "timestamp": 1678886400})
+    mock_session = make_json_session_mock({"block": 19000000, "timestamp": 1678886400})
     client = MoralisClient(mock_config)
     client._session = mock_session
 
@@ -165,7 +150,7 @@ async def test_get_latest_block_number_success(mock_config):
 
 
 async def test_get_latest_block_number_returns_none_on_non_200(mock_config):
-    mock_session = _make_session({}, status=500)
+    mock_session = make_json_session_mock({}, status=500)
     client = MoralisClient(mock_config)
     client._session = mock_session
 
@@ -174,7 +159,7 @@ async def test_get_latest_block_number_returns_none_on_non_200(mock_config):
 
 
 async def test_get_latest_block_number_returns_none_on_missing_field(mock_config):
-    mock_session = _make_session({"date": "2023-03-15"})  # no "block" field
+    mock_session = make_json_session_mock({"date": "2023-03-15"})  # no "block" field
     client = MoralisClient(mock_config)
     client._session = mock_session
 
@@ -207,7 +192,7 @@ async def test_get_latest_block_number_returns_none_on_network_error(mock_config
 
 
 async def test_get_contract_creation_block_success(mock_config):
-    mock_session = _make_session({"block_number": 4634748, "chain": "eth"})
+    mock_session = make_json_session_mock({"block_number": 4634748, "chain": "eth"})
     client = MoralisClient(mock_config)
     client._session = mock_session
 
@@ -216,7 +201,7 @@ async def test_get_contract_creation_block_success(mock_config):
 
 
 async def test_get_contract_creation_block_returns_none_on_missing_field(mock_config):
-    mock_session = _make_session({"some_field": "value"})
+    mock_session = make_json_session_mock({"some_field": "value"})
     client = MoralisClient(mock_config)
     client._session = mock_session
 
@@ -225,7 +210,7 @@ async def test_get_contract_creation_block_returns_none_on_missing_field(mock_co
 
 
 async def test_get_contract_creation_block_returns_none_on_non_200(mock_config):
-    mock_session = _make_session({}, status=404)
+    mock_session = make_json_session_mock({}, status=404)
     client = MoralisClient(mock_config)
     client._session = mock_session
 

--- a/tests/test_notifier.py
+++ b/tests/test_notifier.py
@@ -10,8 +10,6 @@ from usdt_monitor_bot.config import BotConfig, TokenConfig
 from usdt_monitor_bot.notifier import NotificationService
 from usdt_monitor_bot.spam_detector import RiskAnalysis, RiskFlag
 
-pytestmark = pytest.mark.asyncio
-
 # Test data
 USER1 = 123456789
 USER2 = 987654321
@@ -82,7 +80,6 @@ def notifier(mock_telegram_bot, mock_config):
     return NotificationService(mock_telegram_bot, mock_config)
 
 
-@pytest.mark.asyncio
 async def test_send_token_notification_usdt(
     notifier: NotificationService, mock_telegram_bot
 ):
@@ -99,7 +96,6 @@ async def test_send_token_notification_usdt(
     assert "View on Etherscan" in message
 
 
-@pytest.mark.asyncio
 async def test_send_token_notification_usdc(
     notifier: NotificationService, mock_telegram_bot
 ):
@@ -125,7 +121,6 @@ async def test_send_token_notification_usdc(
     assert "View on Etherscan" in message
 
 
-@pytest.mark.asyncio
 async def test_send_token_notification_unknown_token(
     notifier: NotificationService, mock_telegram_bot
 ):
@@ -147,7 +142,6 @@ async def test_send_token_notification_unknown_token(
     notifier._config.token_registry.get_token.assert_called_with("UNKNOWN_TOKEN")  # type: ignore[union-attr]
 
 
-@pytest.mark.asyncio
 async def test_send_token_notification_invalid_value(
     notifier: NotificationService, mock_telegram_bot
 ):
@@ -159,7 +153,6 @@ async def test_send_token_notification_invalid_value(
     mock_telegram_bot.send_message.assert_not_called()
 
 
-@pytest.mark.asyncio
 async def test_send_token_notification_invalid_timestamp(
     notifier: NotificationService, mock_telegram_bot
 ):
@@ -171,7 +164,6 @@ async def test_send_token_notification_invalid_timestamp(
     mock_telegram_bot.send_message.assert_not_called()
 
 
-@pytest.mark.asyncio
 async def test_send_token_notification_outgoing_tx(
     notifier: NotificationService,
     mock_telegram_bot,
@@ -202,7 +194,6 @@ async def test_send_token_notification_outgoing_tx(
     assert "Amount: <b>1.00 USDT</b>" in message
 
 
-@pytest.mark.asyncio
 async def test_send_token_notification_mixed_tx(
     notifier: NotificationService,
     mock_telegram_bot,
@@ -251,7 +242,6 @@ async def test_send_token_notification_mixed_tx(
     assert "Amount: <b>2.00 USDT</b>" in outgoing_message
 
 
-@pytest.mark.asyncio
 async def test_send_token_notification_self_transfer(
     notifier: NotificationService,
     mock_telegram_bot,
@@ -278,7 +268,6 @@ async def test_send_token_notification_self_transfer(
     assert "Amount: <b>1.00 USDT</b>" in message
 
 
-@pytest.mark.asyncio
 async def test_send_token_notification_zero_value(
     notifier: NotificationService,
     mock_telegram_bot,
@@ -304,7 +293,6 @@ async def test_send_token_notification_zero_value(
     assert "Amount: <b>0.00 USDT</b>" in message
 
 
-@pytest.mark.asyncio
 async def test_send_token_notification_large_value(
     notifier: NotificationService,
     mock_telegram_bot,
@@ -330,7 +318,6 @@ async def test_send_token_notification_large_value(
     assert "Amount: <b>1000000.00 USDT</b>" in message
 
 
-@pytest.mark.asyncio
 async def test_send_token_notification_spam_short_notice(
     notifier: NotificationService, mock_telegram_bot
 ):
@@ -369,7 +356,6 @@ async def test_send_token_notification_spam_short_notice(
 # --- Tests for Edge Cases and Error Handling ---
 
 
-@pytest.mark.asyncio
 async def test_send_token_notification_empty_tx(
     notifier: NotificationService, mock_telegram_bot, caplog
 ):
@@ -383,7 +369,6 @@ async def test_send_token_notification_empty_tx(
     assert "Empty tx data" in caplog.text
 
 
-@pytest.mark.asyncio
 async def test_send_token_notification_none_tx(
     notifier: NotificationService, mock_telegram_bot, caplog
 ):
@@ -396,7 +381,6 @@ async def test_send_token_notification_none_tx(
     mock_telegram_bot.send_message.assert_not_called()
 
 
-@pytest.mark.asyncio
 async def test_send_token_notification_invalid_user_id(
     notifier: NotificationService, mock_telegram_bot, caplog
 ):
@@ -417,7 +401,6 @@ async def test_send_token_notification_invalid_user_id(
     assert "Invalid user_id" in caplog.text
 
 
-@pytest.mark.asyncio
 async def test_send_token_notification_telegram_api_error(
     notifier: NotificationService, mock_telegram_bot, caplog
 ):
@@ -434,7 +417,6 @@ async def test_send_token_notification_telegram_api_error(
     assert "Send failed" in caplog.text
 
 
-@pytest.mark.asyncio
 async def test_format_token_message_missing_tx_hash(notifier: NotificationService):
     """Test that missing tx_hash returns None."""
     result = notifier._format_token_message(
@@ -448,7 +430,6 @@ async def test_format_token_message_missing_tx_hash(notifier: NotificationServic
     assert result is None
 
 
-@pytest.mark.asyncio
 async def test_format_token_message_invalid_tx_hash_format(
     notifier: NotificationService,
 ):
@@ -464,7 +445,6 @@ async def test_format_token_message_invalid_tx_hash_format(
     assert result is None
 
 
-@pytest.mark.asyncio
 async def test_format_token_message_invalid_address_format(
     notifier: NotificationService,
 ):
@@ -480,7 +460,6 @@ async def test_format_token_message_invalid_address_format(
     assert result is None
 
 
-@pytest.mark.asyncio
 async def test_format_token_message_negative_value(notifier: NotificationService):
     """Test that negative value returns None."""
     result = notifier._format_token_message(
@@ -494,7 +473,6 @@ async def test_format_token_message_negative_value(notifier: NotificationService
     assert result is None
 
 
-@pytest.mark.asyncio
 async def test_format_token_message_future_timestamp(notifier: NotificationService):
     """Test that far future timestamp returns None."""
     # Timestamp 2 hours in the future (beyond allowed tolerance)
@@ -511,7 +489,6 @@ async def test_format_token_message_future_timestamp(notifier: NotificationServi
     assert result is None
 
 
-@pytest.mark.asyncio
 async def test_format_token_message_negative_timestamp(notifier: NotificationService):
     """Test that negative timestamp returns None."""
     result = notifier._format_token_message(
@@ -525,7 +502,6 @@ async def test_format_token_message_negative_timestamp(notifier: NotificationSer
     assert result is None
 
 
-@pytest.mark.asyncio
 async def test_format_token_message_non_integer_timestamp(
     notifier: NotificationService,
 ):
@@ -541,7 +517,6 @@ async def test_format_token_message_non_integer_timestamp(
     assert result is None
 
 
-@pytest.mark.asyncio
 async def test_send_notification_case_insensitive_address_comparison(
     notifier: NotificationService, mock_telegram_bot
 ):

--- a/tests/test_spam_detector.py
+++ b/tests/test_spam_detector.py
@@ -53,12 +53,6 @@ def similar_address():
     return "0x1234abcdefabcdefabcdefabcdefabcdefab7890"
 
 
-@pytest.fixture
-def different_address():
-    """Provides a completely different address."""
-    return "0x1234567890123456789012345678901234567890"
-
-
 # --- Test Address Similarity Calculation ---
 
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -5,70 +5,70 @@ Tests for utility functions like address validation.
 Note: Token message formatting tests are in test_notifier.py.
 """
 
+import pytest
+
 from usdt_monitor_bot.handlers import is_valid_ethereum_address
 
 
 class TestAddressValidation:
     """Tests for Ethereum address validation."""
 
-    def test_valid_lowercase_address(self):
-        """Valid lowercase hex address should pass."""
-        assert is_valid_ethereum_address("0x1234567890123456789012345678901234567890")
-        assert is_valid_ethereum_address("0xabcdef0123456789abcdef0123456789abcdef01")
+    @pytest.mark.parametrize(
+        "addr",
+        [
+            "0x1234567890123456789012345678901234567890",
+            "0xabcdef0123456789abcdef0123456789abcdef01",
+        ],
+        ids=["lower_0_9", "lower_a_f"],
+    )
+    def test_valid_lowercase_address(self, addr: str):
+        assert is_valid_ethereum_address(addr)
 
     def test_valid_uppercase_address(self):
-        """Valid uppercase hex address should pass."""
         assert is_valid_ethereum_address("0xABCDEF0123456789ABCDEF0123456789ABCDEF01")
 
     def test_valid_mixed_case_address(self):
-        """Valid mixed case hex address should pass."""
         assert is_valid_ethereum_address("0xAbCdEf0123456789aBcDeF0123456789AbCdEf01")
 
-    def test_invalid_no_0x_prefix(self):
-        """Address without 0x prefix should fail."""
-        assert not is_valid_ethereum_address(
-            "1234567890123456789012345678901234567890"
-        )
-
-    def test_invalid_too_short(self):
-        """Address that's too short should fail."""
-        assert not is_valid_ethereum_address("0x123")
-        assert not is_valid_ethereum_address("0x12345678901234567890123456789012345678")
-
-    def test_invalid_too_long(self):
-        """Address that's too long should fail."""
-        assert not is_valid_ethereum_address(
-            "0x123456789012345678901234567890123456789012"
-        )
-
-    def test_invalid_non_hex_characters(self):
-        """Address with non-hex characters should fail."""
-        assert not is_valid_ethereum_address(
-            "0xghijklmnopqrstuvwxyz1234567890123456"
-        )
-        assert not is_valid_ethereum_address(
-            "0x123456789012345678901234567890123456789g"
-        )
-
-    def test_invalid_not_an_address(self):
-        """Random strings should fail."""
-        assert not is_valid_ethereum_address("not_an_address")
-        assert not is_valid_ethereum_address("")
-        assert not is_valid_ethereum_address("hello world")
+    @pytest.mark.parametrize(
+        "addr",
+        [
+            "1234567890123456789012345678901234567890",
+            "0x123",
+            "0x12345678901234567890123456789012345678",
+            "0x123456789012345678901234567890123456789012",
+            "0xghijklmnopqrstuvwxyz1234567890123456",
+            "0x123456789012345678901234567890123456789g",
+            "not_an_address",
+            "",
+            "hello world",
+        ],
+        ids=[
+            "no_0x",
+            "too_short_0x123",
+            "too_short_39_hex",
+            "too_long",
+            "non_hex_letters",
+            "non_hex_tail",
+            "not_address",
+            "empty",
+            "hello_world",
+        ],
+    )
+    def test_invalid_addresses_rejected(self, addr: str):
+        assert not is_valid_ethereum_address(addr)
 
     def test_invalid_none_input(self):
-        """None input should fail gracefully."""
         assert not is_valid_ethereum_address(None)
 
-    def test_invalid_non_string_input(self):
-        """Non-string inputs should fail gracefully."""
-        assert not is_valid_ethereum_address(12345)  # type: ignore[arg-type]
-        assert not is_valid_ethereum_address(["0x1234567890123456789012345678901234567890"])  # type: ignore[arg-type]
-        assert not is_valid_ethereum_address({"address": "0x123"})  # type: ignore[arg-type]
+    @pytest.mark.parametrize(
+        "addr",
+        [12345, ["0x1234567890123456789012345678901234567890"], {"address": "0x123"}],
+        ids=["int", "list", "dict"],
+    )
+    def test_invalid_non_string_input(self, addr: object):
+        assert not is_valid_ethereum_address(addr)  # type: ignore[arg-type]
 
     def test_valid_checksum_address(self):
-        """EIP-55 checksum addresses should pass (we don't validate checksum, just format)."""
-        # Real USDT contract address
         assert is_valid_ethereum_address("0xdAC17F958D2ee523a2206206994597C13D831ec7")
-        # Real USDC contract address
         assert is_valid_ethereum_address("0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48")

--- a/uv.lock
+++ b/uv.lock
@@ -1,0 +1,1007 @@
+version = 1
+revision = 3
+requires-python = ">=3.14"
+
+[[package]]
+name = "aiofiles"
+version = "25.1.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/41/c3/534eac40372d8ee36ef40df62ec129bee4fdb5ad9706e58a29be53b2c970/aiofiles-25.1.0.tar.gz", hash = "sha256:a8d728f0a29de45dc521f18f07297428d56992a742f0cd2701ba86e44d23d5b2", size = 46354, upload-time = "2025-10-09T20:51:04.358Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/bc/8a/340a1555ae33d7354dbca4faa54948d76d89a27ceef032c8c3bc661d003e/aiofiles-25.1.0-py3-none-any.whl", hash = "sha256:abe311e527c862958650f9438e859c1fa7568a141b22abcd015e120e86a85695", size = 14668, upload-time = "2025-10-09T20:51:03.174Z" },
+]
+
+[[package]]
+name = "aiogram"
+version = "3.26.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "aiofiles" },
+    { name = "aiohttp" },
+    { name = "certifi" },
+    { name = "magic-filter" },
+    { name = "pydantic" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/dd/2b/11709d58a7c47a773cd47239c7b5db258f02f31d784265bddeb562f3e9f9/aiogram-3.26.0.tar.gz", hash = "sha256:12fa1bce9c8cee0f1214f5e3f91bb631586c4503854d6138dacbdd7e7dc1020c", size = 1729985, upload-time = "2026-03-02T23:29:20.843Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/da/48/8504168e7a3ede9577a2d8aa0ed3f13471ef2db6431f506105b94f284d05/aiogram-3.26.0-py3-none-any.whl", hash = "sha256:dd8ea7feb2409953ad1424564355926207af90bb2204e37be7373fe6de201016", size = 716388, upload-time = "2026-03-02T23:29:19.076Z" },
+]
+
+[[package]]
+name = "aiohappyeyeballs"
+version = "2.6.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/26/30/f84a107a9c4331c14b2b586036f40965c128aa4fee4dda5d3d51cb14ad54/aiohappyeyeballs-2.6.1.tar.gz", hash = "sha256:c3f9d0113123803ccadfdf3f0faa505bc78e6a72d1cc4806cbd719826e943558", size = 22760, upload-time = "2025-03-12T01:42:48.764Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/0f/15/5bf3b99495fb160b63f95972b81750f18f7f4e02ad051373b669d17d44f2/aiohappyeyeballs-2.6.1-py3-none-any.whl", hash = "sha256:f349ba8f4b75cb25c99c5c2d84e997e485204d2902a9597802b0371f09331fb8", size = 15265, upload-time = "2025-03-12T01:42:47.083Z" },
+]
+
+[[package]]
+name = "aiohttp"
+version = "3.13.5"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "aiohappyeyeballs" },
+    { name = "aiosignal" },
+    { name = "attrs" },
+    { name = "frozenlist" },
+    { name = "multidict" },
+    { name = "propcache" },
+    { name = "yarl" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/77/9a/152096d4808df8e4268befa55fba462f440f14beab85e8ad9bf990516918/aiohttp-3.13.5.tar.gz", hash = "sha256:9d98cc980ecc96be6eb4c1994ce35d28d8b1f5e5208a23b421187d1209dbb7d1", size = 7858271, upload-time = "2026-03-31T22:01:03.343Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5d/ce/46572759afc859e867a5bc8ec3487315869013f59281ce61764f76d879de/aiohttp-3.13.5-cp314-cp314-macosx_10_13_universal2.whl", hash = "sha256:eb4639f32fd4a9904ab8fb45bf3383ba71137f3d9d4ba25b3b3f3109977c5b8c", size = 745721, upload-time = "2026-03-31T21:58:50.229Z" },
+    { url = "https://files.pythonhosted.org/packages/13/fe/8a2efd7626dbe6049b2ef8ace18ffda8a4dfcbe1bcff3ac30c0c7575c20b/aiohttp-3.13.5-cp314-cp314-macosx_10_13_x86_64.whl", hash = "sha256:7e5dc4311bd5ac493886c63cbf76ab579dbe4641268e7c74e48e774c74b6f2be", size = 497663, upload-time = "2026-03-31T21:58:52.232Z" },
+    { url = "https://files.pythonhosted.org/packages/9b/91/cc8cc78a111826c54743d88651e1687008133c37e5ee615fee9b57990fac/aiohttp-3.13.5-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:756c3c304d394977519824449600adaf2be0ccee76d206ee339c5e76b70ded25", size = 499094, upload-time = "2026-03-31T21:58:54.566Z" },
+    { url = "https://files.pythonhosted.org/packages/0a/33/a8362cb15cf16a3af7e86ed11962d5cd7d59b449202dc576cdc731310bde/aiohttp-3.13.5-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:ecc26751323224cf8186efcf7fbcbc30f4e1d8c7970659daf25ad995e4032a56", size = 1726701, upload-time = "2026-03-31T21:58:56.864Z" },
+    { url = "https://files.pythonhosted.org/packages/45/0c/c091ac5c3a17114bd76cbf85d674650969ddf93387876cf67f754204bd77/aiohttp-3.13.5-cp314-cp314-manylinux2014_armv7l.manylinux_2_17_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:10a75acfcf794edf9d8db50e5a7ec5fc818b2a8d3f591ce93bc7b1210df016d2", size = 1683360, upload-time = "2026-03-31T21:58:59.072Z" },
+    { url = "https://files.pythonhosted.org/packages/23/73/bcee1c2b79bc275e964d1446c55c54441a461938e70267c86afaae6fba27/aiohttp-3.13.5-cp314-cp314-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:0f7a18f258d124cd678c5fe072fe4432a4d5232b0657fca7c1847f599233c83a", size = 1773023, upload-time = "2026-03-31T21:59:01.776Z" },
+    { url = "https://files.pythonhosted.org/packages/c7/ef/720e639df03004fee2d869f771799d8c23046dec47d5b81e396c7cda583a/aiohttp-3.13.5-cp314-cp314-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:df6104c009713d3a89621096f3e3e88cc323fd269dbd7c20afe18535094320be", size = 1853795, upload-time = "2026-03-31T21:59:04.568Z" },
+    { url = "https://files.pythonhosted.org/packages/bd/c9/989f4034fb46841208de7aeeac2c6d8300745ab4f28c42f629ba77c2d916/aiohttp-3.13.5-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:241a94f7de7c0c3b616627aaad530fe2cb620084a8b144d3be7b6ecfe95bae3b", size = 1730405, upload-time = "2026-03-31T21:59:07.221Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/75/ee1fd286ca7dc599d824b5651dad7b3be7ff8d9a7e7b3fe9820d9180f7db/aiohttp-3.13.5-cp314-cp314-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:c974fb66180e58709b6fc402846f13791240d180b74de81d23913abe48e96d94", size = 1558082, upload-time = "2026-03-31T21:59:09.484Z" },
+    { url = "https://files.pythonhosted.org/packages/c3/20/1e9e6650dfc436340116b7aa89ff8cb2bbdf0abc11dfaceaad8f74273a10/aiohttp-3.13.5-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:6e27ea05d184afac78aabbac667450c75e54e35f62238d44463131bd3f96753d", size = 1692346, upload-time = "2026-03-31T21:59:12.068Z" },
+    { url = "https://files.pythonhosted.org/packages/d8/40/8ebc6658d48ea630ac7903912fe0dd4e262f0e16825aa4c833c56c9f1f56/aiohttp-3.13.5-cp314-cp314-musllinux_1_2_armv7l.whl", hash = "sha256:a79a6d399cef33a11b6f004c67bb07741d91f2be01b8d712d52c75711b1e07c7", size = 1698891, upload-time = "2026-03-31T21:59:14.552Z" },
+    { url = "https://files.pythonhosted.org/packages/d8/78/ea0ae5ec8ba7a5c10bdd6e318f1ba5e76fcde17db8275188772afc7917a4/aiohttp-3.13.5-cp314-cp314-musllinux_1_2_ppc64le.whl", hash = "sha256:c632ce9c0b534fbe25b52c974515ed674937c5b99f549a92127c85f771a78772", size = 1742113, upload-time = "2026-03-31T21:59:17.068Z" },
+    { url = "https://files.pythonhosted.org/packages/8a/66/9d308ed71e3f2491be1acb8769d96c6f0c47d92099f3bc9119cada27b357/aiohttp-3.13.5-cp314-cp314-musllinux_1_2_riscv64.whl", hash = "sha256:fceedde51fbd67ee2bcc8c0b33d0126cc8b51ef3bbde2f86662bd6d5a6f10ec5", size = 1553088, upload-time = "2026-03-31T21:59:19.541Z" },
+    { url = "https://files.pythonhosted.org/packages/da/a6/6cc25ed8dfc6e00c90f5c6d126a98e2cf28957ad06fa1036bd34b6f24a2c/aiohttp-3.13.5-cp314-cp314-musllinux_1_2_s390x.whl", hash = "sha256:f92995dfec9420bb69ae629abf422e516923ba79ba4403bc750d94fb4a6c68c1", size = 1757976, upload-time = "2026-03-31T21:59:22.311Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/2b/cce5b0ffe0de99c83e5e36d8f828e4161e415660a9f3e58339d07cce3006/aiohttp-3.13.5-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:20ae0ff08b1f2c8788d6fb85afcb798654ae6ba0b747575f8562de738078457b", size = 1712444, upload-time = "2026-03-31T21:59:24.635Z" },
+    { url = "https://files.pythonhosted.org/packages/6c/cf/9e1795b4160c58d29421eafd1a69c6ce351e2f7c8d3c6b7e4ca44aea1a5b/aiohttp-3.13.5-cp314-cp314-win32.whl", hash = "sha256:b20df693de16f42b2472a9c485e1c948ee55524786a0a34345511afdd22246f3", size = 438128, upload-time = "2026-03-31T21:59:27.291Z" },
+    { url = "https://files.pythonhosted.org/packages/22/4d/eaedff67fc805aeba4ba746aec891b4b24cebb1a7d078084b6300f79d063/aiohttp-3.13.5-cp314-cp314-win_amd64.whl", hash = "sha256:f85c6f327bf0b8c29da7d93b1cabb6363fb5e4e160a32fa241ed2dce21b73162", size = 464029, upload-time = "2026-03-31T21:59:29.429Z" },
+    { url = "https://files.pythonhosted.org/packages/79/11/c27d9332ee20d68dd164dc12a6ecdef2e2e35ecc97ed6cf0d2442844624b/aiohttp-3.13.5-cp314-cp314t-macosx_10_13_universal2.whl", hash = "sha256:1efb06900858bb618ff5cee184ae2de5828896c448403d51fb633f09e109be0a", size = 778758, upload-time = "2026-03-31T21:59:31.547Z" },
+    { url = "https://files.pythonhosted.org/packages/04/fb/377aead2e0a3ba5f09b7624f702a964bdf4f08b5b6728a9799830c80041e/aiohttp-3.13.5-cp314-cp314t-macosx_10_13_x86_64.whl", hash = "sha256:fee86b7c4bd29bdaf0d53d14739b08a106fdda809ca5fe032a15f52fae5fe254", size = 512883, upload-time = "2026-03-31T21:59:34.098Z" },
+    { url = "https://files.pythonhosted.org/packages/bb/a6/aa109a33671f7a5d3bd78b46da9d852797c5e665bfda7d6b373f56bff2ec/aiohttp-3.13.5-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:20058e23909b9e65f9da62b396b77dfa95965cbe840f8def6e572538b1d32e36", size = 516668, upload-time = "2026-03-31T21:59:36.497Z" },
+    { url = "https://files.pythonhosted.org/packages/79/b3/ca078f9f2fa9563c36fb8ef89053ea2bb146d6f792c5104574d49d8acb63/aiohttp-3.13.5-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:8cf20a8d6868cb15a73cab329ffc07291ba8c22b1b88176026106ae39aa6df0f", size = 1883461, upload-time = "2026-03-31T21:59:38.723Z" },
+    { url = "https://files.pythonhosted.org/packages/b7/e3/a7ad633ca1ca497b852233a3cce6906a56c3225fb6d9217b5e5e60b7419d/aiohttp-3.13.5-cp314-cp314t-manylinux2014_armv7l.manylinux_2_17_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:330f5da04c987f1d5bdb8ae189137c77139f36bd1cb23779ca1a354a4b027800", size = 1747661, upload-time = "2026-03-31T21:59:41.187Z" },
+    { url = "https://files.pythonhosted.org/packages/33/b9/cd6fe579bed34a906d3d783fe60f2fa297ef55b27bb4538438ee49d4dc41/aiohttp-3.13.5-cp314-cp314t-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:6f1cbf0c7926d315c3c26c2da41fd2b5d2fe01ac0e157b78caefc51a782196cf", size = 1863800, upload-time = "2026-03-31T21:59:43.84Z" },
+    { url = "https://files.pythonhosted.org/packages/c0/3f/2c1e2f5144cefa889c8afd5cf431994c32f3b29da9961698ff4e3811b79a/aiohttp-3.13.5-cp314-cp314t-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:53fc049ed6390d05423ba33103ded7281fe897cf97878f369a527070bd95795b", size = 1958382, upload-time = "2026-03-31T21:59:46.187Z" },
+    { url = "https://files.pythonhosted.org/packages/66/1d/f31ec3f1013723b3babe3609e7f119c2c2fb6ef33da90061a705ef3e1bc8/aiohttp-3.13.5-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:898703aa2667e3c5ca4c54ca36cd73f58b7a38ef87a5606414799ebce4d3fd3a", size = 1803724, upload-time = "2026-03-31T21:59:48.656Z" },
+    { url = "https://files.pythonhosted.org/packages/0e/b4/57712dfc6f1542f067daa81eb61da282fab3e6f1966fca25db06c4fc62d5/aiohttp-3.13.5-cp314-cp314t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:0494a01ca9584eea1e5fbd6d748e61ecff218c51b576ee1999c23db7066417d8", size = 1640027, upload-time = "2026-03-31T21:59:51.284Z" },
+    { url = "https://files.pythonhosted.org/packages/25/3c/734c878fb43ec083d8e31bf029daae1beafeae582d1b35da234739e82ee7/aiohttp-3.13.5-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:6cf81fe010b8c17b09495cbd15c1d35afbc8fb405c0c9cf4738e5ae3af1d65be", size = 1806644, upload-time = "2026-03-31T21:59:53.753Z" },
+    { url = "https://files.pythonhosted.org/packages/20/a5/f671e5cbec1c21d044ff3078223f949748f3a7f86b14e34a365d74a5d21f/aiohttp-3.13.5-cp314-cp314t-musllinux_1_2_armv7l.whl", hash = "sha256:c564dd5f09ddc9d8f2c2d0a301cd30a79a2cc1b46dd1a73bef8f0038863d016b", size = 1791630, upload-time = "2026-03-31T21:59:56.239Z" },
+    { url = "https://files.pythonhosted.org/packages/0b/63/fb8d0ad63a0b8a99be97deac8c04dacf0785721c158bdf23d679a87aa99e/aiohttp-3.13.5-cp314-cp314t-musllinux_1_2_ppc64le.whl", hash = "sha256:2994be9f6e51046c4f864598fd9abeb4fba6e88f0b2152422c9666dcd4aea9c6", size = 1809403, upload-time = "2026-03-31T21:59:59.103Z" },
+    { url = "https://files.pythonhosted.org/packages/59/0c/bfed7f30662fcf12206481c2aac57dedee43fe1c49275e85b3a1e1742294/aiohttp-3.13.5-cp314-cp314t-musllinux_1_2_riscv64.whl", hash = "sha256:157826e2fa245d2ef46c83ea8a5faf77ca19355d278d425c29fda0beb3318037", size = 1634924, upload-time = "2026-03-31T22:00:02.116Z" },
+    { url = "https://files.pythonhosted.org/packages/17/d6/fd518d668a09fd5a3319ae5e984d4d80b9a4b3df4e21c52f02251ef5a32e/aiohttp-3.13.5-cp314-cp314t-musllinux_1_2_s390x.whl", hash = "sha256:a8aca50daa9493e9e13c0f566201a9006f080e7c50e5e90d0b06f53146a54500", size = 1836119, upload-time = "2026-03-31T22:00:04.756Z" },
+    { url = "https://files.pythonhosted.org/packages/78/b7/15fb7a9d52e112a25b621c67b69c167805cb1f2ab8f1708a5c490d1b52fe/aiohttp-3.13.5-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:3b13560160d07e047a93f23aaa30718606493036253d5430887514715b67c9d9", size = 1772072, upload-time = "2026-03-31T22:00:07.494Z" },
+    { url = "https://files.pythonhosted.org/packages/7e/df/57ba7f0c4a553fc2bd8b6321df236870ec6fd64a2a473a8a13d4f733214e/aiohttp-3.13.5-cp314-cp314t-win32.whl", hash = "sha256:9a0f4474b6ea6818b41f82172d799e4b3d29e22c2c520ce4357856fced9af2f8", size = 471819, upload-time = "2026-03-31T22:00:10.277Z" },
+    { url = "https://files.pythonhosted.org/packages/62/29/2f8418269e46454a26171bfdd6a055d74febf32234e474930f2f60a17145/aiohttp-3.13.5-cp314-cp314t-win_amd64.whl", hash = "sha256:18a2f6c1182c51baa1d28d68fea51513cb2a76612f038853c0ad3c145423d3d9", size = 505441, upload-time = "2026-03-31T22:00:12.791Z" },
+]
+
+[[package]]
+name = "aiosignal"
+version = "1.4.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "frozenlist" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/61/62/06741b579156360248d1ec624842ad0edf697050bbaf7c3e46394e106ad1/aiosignal-1.4.0.tar.gz", hash = "sha256:f47eecd9468083c2029cc99945502cb7708b082c232f9aca65da147157b251c7", size = 25007, upload-time = "2025-07-03T22:54:43.528Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/fb/76/641ae371508676492379f16e2fa48f4e2c11741bd63c48be4b12a6b09cba/aiosignal-1.4.0-py3-none-any.whl", hash = "sha256:053243f8b92b990551949e63930a839ff0cf0b0ebbe0597b0f3fb19e1a0fe82e", size = 7490, upload-time = "2025-07-03T22:54:42.156Z" },
+]
+
+[[package]]
+name = "annotated-types"
+version = "0.7.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/ee/67/531ea369ba64dcff5ec9c3402f9f51bf748cec26dde048a2f973a4eea7f5/annotated_types-0.7.0.tar.gz", hash = "sha256:aff07c09a53a08bc8cfccb9c85b05f1aa9a2a6f23728d790723543408344ce89", size = 16081, upload-time = "2024-05-20T21:33:25.928Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/78/b6/6307fbef88d9b5ee7421e68d78a9f162e0da4900bc5f5793f6d3d0e34fb8/annotated_types-0.7.0-py3-none-any.whl", hash = "sha256:1f02e8b43a8fbbc3f3e0d4f0f4bfc8131bcb4eebe8849b8e5c773f3a1c582a53", size = 13643, upload-time = "2024-05-20T21:33:24.1Z" },
+]
+
+[[package]]
+name = "apscheduler"
+version = "3.11.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "tzlocal" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/07/12/3e4389e5920b4c1763390c6d371162f3784f86f85cd6d6c1bfe68eef14e2/apscheduler-3.11.2.tar.gz", hash = "sha256:2a9966b052ec805f020c8c4c3ae6e6a06e24b1bf19f2e11d91d8cca0473eef41", size = 108683, upload-time = "2025-12-22T00:39:34.884Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9f/64/2e54428beba8d9992aa478bb8f6de9e4ecaa5f8f513bcfd567ed7fb0262d/apscheduler-3.11.2-py3-none-any.whl", hash = "sha256:ce005177f741409db4e4dd40a7431b76feb856b9dd69d57e0da49d6715bfd26d", size = 64439, upload-time = "2025-12-22T00:39:33.303Z" },
+]
+
+[[package]]
+name = "attrs"
+version = "26.1.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/9a/8e/82a0fe20a541c03148528be8cac2408564a6c9a0cc7e9171802bc1d26985/attrs-26.1.0.tar.gz", hash = "sha256:d03ceb89cb322a8fd706d4fb91940737b6642aa36998fe130a9bc96c985eff32", size = 952055, upload-time = "2026-03-19T14:22:25.026Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/64/b4/17d4b0b2a2dc85a6df63d1157e028ed19f90d4cd97c36717afef2bc2f395/attrs-26.1.0-py3-none-any.whl", hash = "sha256:c647aa4a12dfbad9333ca4e71fe62ddc36f4e63b2d260a37a8b83d2f043ac309", size = 67548, upload-time = "2026-03-19T14:22:23.645Z" },
+]
+
+[[package]]
+name = "bandit"
+version = "1.9.4"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "pyyaml" },
+    { name = "rich" },
+    { name = "stevedore" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/aa/c3/0cb80dfe0f3076e5da7e4c5ad8e57bac6ac357ff4a6406205501cade4965/bandit-1.9.4.tar.gz", hash = "sha256:b589e5de2afe70bd4d53fa0c1da6199f4085af666fde00e8a034f152a52cd628", size = 4242677, upload-time = "2026-02-25T06:44:15.503Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/05/a4/a26d5b25671d27e03afb5401a0be5899d94ff8fab6a698b1ac5be3ec29ef/bandit-1.9.4-py3-none-any.whl", hash = "sha256:f89ffa663767f5a0585ea075f01020207e966a9c0f2b9ef56a57c7963a3f6f8e", size = 134741, upload-time = "2026-02-25T06:44:13.694Z" },
+]
+
+[[package]]
+name = "boolean-py"
+version = "5.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/c4/cf/85379f13b76f3a69bca86b60237978af17d6aa0bc5998978c3b8cf05abb2/boolean_py-5.0.tar.gz", hash = "sha256:60cbc4bad079753721d32649545505362c754e121570ada4658b852a3a318d95", size = 37047, upload-time = "2025-04-03T10:39:49.734Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e5/ca/78d423b324b8d77900030fa59c4aa9054261ef0925631cd2501dd015b7b7/boolean_py-5.0-py3-none-any.whl", hash = "sha256:ef28a70bd43115208441b53a045d1549e2f0ec6e3d08a9d142cbc41c1938e8d9", size = 26577, upload-time = "2025-04-03T10:39:48.449Z" },
+]
+
+[[package]]
+name = "cachecontrol"
+version = "0.14.4"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "msgpack" },
+    { name = "requests" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/2d/f6/c972b32d80760fb79d6b9eeb0b3010a46b89c0b23cf6329417ff7886cd22/cachecontrol-0.14.4.tar.gz", hash = "sha256:e6220afafa4c22a47dd0badb319f84475d79108100d04e26e8542ef7d3ab05a1", size = 16150, upload-time = "2025-11-14T04:32:13.138Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ef/79/c45f2d53efe6ada1110cf6f9fca095e4ff47a0454444aefdde6ac4789179/cachecontrol-0.14.4-py3-none-any.whl", hash = "sha256:b7ac014ff72ee199b5f8af1de29d60239954f223e948196fa3d84adaffc71d2b", size = 22247, upload-time = "2025-11-14T04:32:11.733Z" },
+]
+
+[package.optional-dependencies]
+filecache = [
+    { name = "filelock" },
+]
+
+[[package]]
+name = "certifi"
+version = "2026.2.25"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/af/2d/7bf41579a8986e348fa033a31cdd0e4121114f6bce2457e8876010b092dd/certifi-2026.2.25.tar.gz", hash = "sha256:e887ab5cee78ea814d3472169153c2d12cd43b14bd03329a39a9c6e2e80bfba7", size = 155029, upload-time = "2026-02-25T02:54:17.342Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9a/3c/c17fb3ca2d9c3acff52e30b309f538586f9f5b9c9cf454f3845fc9af4881/certifi-2026.2.25-py3-none-any.whl", hash = "sha256:027692e4402ad994f1c42e52a4997a9763c646b73e4096e4d5d6db8af1d6f0fa", size = 153684, upload-time = "2026-02-25T02:54:15.766Z" },
+]
+
+[[package]]
+name = "charset-normalizer"
+version = "3.4.7"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/e7/a1/67fe25fac3c7642725500a3f6cfe5821ad557c3abb11c9d20d12c7008d3e/charset_normalizer-3.4.7.tar.gz", hash = "sha256:ae89db9e5f98a11a4bf50407d4363e7b09b31e55bc117b4f7d80aab97ba009e5", size = 144271, upload-time = "2026-04-02T09:28:39.342Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/97/c8/c67cb8c70e19ef1960b97b22ed2a1567711de46c4ddf19799923adc836c2/charset_normalizer-3.4.7-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:c36c333c39be2dbca264d7803333c896ab8fa7d4d6f0ab7edb7dfd7aea6e98c0", size = 309234, upload-time = "2026-04-02T09:27:07.194Z" },
+    { url = "https://files.pythonhosted.org/packages/99/85/c091fdee33f20de70d6c8b522743b6f831a2f1cd3ff86de4c6a827c48a76/charset_normalizer-3.4.7-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:1c2aed2e5e41f24ea8ef1590b8e848a79b56f3a5564a65ceec43c9d692dc7d8a", size = 208042, upload-time = "2026-04-02T09:27:08.749Z" },
+    { url = "https://files.pythonhosted.org/packages/87/1c/ab2ce611b984d2fd5d86a5a8a19c1ae26acac6bad967da4967562c75114d/charset_normalizer-3.4.7-cp314-cp314-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:54523e136b8948060c0fa0bc7b1b50c32c186f2fceee897a495406bb6e311d2b", size = 228706, upload-time = "2026-04-02T09:27:09.951Z" },
+    { url = "https://files.pythonhosted.org/packages/a8/29/2b1d2cb00bf085f59d29eb773ce58ec2d325430f8c216804a0a5cd83cbca/charset_normalizer-3.4.7-cp314-cp314-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:715479b9a2802ecac752a3b0efa2b0b60285cf962ee38414211abdfccc233b41", size = 224727, upload-time = "2026-04-02T09:27:11.175Z" },
+    { url = "https://files.pythonhosted.org/packages/47/5c/032c2d5a07fe4d4855fea851209cca2b6f03ebeb6d4e3afdb3358386a684/charset_normalizer-3.4.7-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:bd6c2a1c7573c64738d716488d2cdd3c00e340e4835707d8fdb8dc1a66ef164e", size = 215882, upload-time = "2026-04-02T09:27:12.446Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/c2/356065d5a8b78ed04499cae5f339f091946a6a74f91e03476c33f0ab7100/charset_normalizer-3.4.7-cp314-cp314-manylinux_2_31_armv7l.whl", hash = "sha256:c45e9440fb78f8ddabcf714b68f936737a121355bf59f3907f4e17721b9d1aae", size = 200860, upload-time = "2026-04-02T09:27:13.721Z" },
+    { url = "https://files.pythonhosted.org/packages/0c/cd/a32a84217ced5039f53b29f460962abb2d4420def55afabe45b1c3c7483d/charset_normalizer-3.4.7-cp314-cp314-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:3534e7dcbdcf757da6b85a0bbf5b6868786d5982dd959b065e65481644817a18", size = 211564, upload-time = "2026-04-02T09:27:15.272Z" },
+    { url = "https://files.pythonhosted.org/packages/44/86/58e6f13ce26cc3b8f4a36b94a0f22ae2f00a72534520f4ae6857c4b81f89/charset_normalizer-3.4.7-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:e8ac484bf18ce6975760921bb6148041faa8fef0547200386ea0b52b5d27bf7b", size = 211276, upload-time = "2026-04-02T09:27:16.834Z" },
+    { url = "https://files.pythonhosted.org/packages/8f/fe/d17c32dc72e17e155e06883efa84514ca375f8a528ba2546bee73fc4df81/charset_normalizer-3.4.7-cp314-cp314-musllinux_1_2_armv7l.whl", hash = "sha256:a5fe03b42827c13cdccd08e6c0247b6a6d4b5e3cdc53fd1749f5896adcdc2356", size = 201238, upload-time = "2026-04-02T09:27:18.229Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/29/f33daa50b06525a237451cdb6c69da366c381a3dadcd833fa5676bc468b3/charset_normalizer-3.4.7-cp314-cp314-musllinux_1_2_ppc64le.whl", hash = "sha256:2d6eb928e13016cea4f1f21d1e10c1cebd5a421bc57ddf5b1142ae3f86824fab", size = 230189, upload-time = "2026-04-02T09:27:19.445Z" },
+    { url = "https://files.pythonhosted.org/packages/b6/6e/52c84015394a6a0bdcd435210a7e944c5f94ea1055f5cc5d56c5fe368e7b/charset_normalizer-3.4.7-cp314-cp314-musllinux_1_2_riscv64.whl", hash = "sha256:e74327fb75de8986940def6e8dee4f127cc9752bee7355bb323cc5b2659b6d46", size = 211352, upload-time = "2026-04-02T09:27:20.79Z" },
+    { url = "https://files.pythonhosted.org/packages/8c/d7/4353be581b373033fb9198bf1da3cf8f09c1082561e8e922aa7b39bf9fe8/charset_normalizer-3.4.7-cp314-cp314-musllinux_1_2_s390x.whl", hash = "sha256:d6038d37043bced98a66e68d3aa2b6a35505dc01328cd65217cefe82f25def44", size = 227024, upload-time = "2026-04-02T09:27:22.063Z" },
+    { url = "https://files.pythonhosted.org/packages/30/45/99d18aa925bd1740098ccd3060e238e21115fffbfdcb8f3ece837d0ace6c/charset_normalizer-3.4.7-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:7579e913a5339fb8fa133f6bbcfd8e6749696206cf05acdbdca71a1b436d8e72", size = 217869, upload-time = "2026-04-02T09:27:23.486Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/05/5ee478aa53f4bb7996482153d4bfe1b89e0f087f0ab6b294fcf92d595873/charset_normalizer-3.4.7-cp314-cp314-win32.whl", hash = "sha256:5b77459df20e08151cd6f8b9ef8ef1f961ef73d85c21a555c7eed5b79410ec10", size = 148541, upload-time = "2026-04-02T09:27:25.146Z" },
+    { url = "https://files.pythonhosted.org/packages/48/77/72dcb0921b2ce86420b2d79d454c7022bf5be40202a2a07906b9f2a35c97/charset_normalizer-3.4.7-cp314-cp314-win_amd64.whl", hash = "sha256:92a0a01ead5e668468e952e4238cccd7c537364eb7d851ab144ab6627dbbe12f", size = 159634, upload-time = "2026-04-02T09:27:26.642Z" },
+    { url = "https://files.pythonhosted.org/packages/c6/a3/c2369911cd72f02386e4e340770f6e158c7980267da16af8f668217abaa0/charset_normalizer-3.4.7-cp314-cp314-win_arm64.whl", hash = "sha256:67f6279d125ca0046a7fd386d01b311c6363844deac3e5b069b514ba3e63c246", size = 148384, upload-time = "2026-04-02T09:27:28.271Z" },
+    { url = "https://files.pythonhosted.org/packages/94/09/7e8a7f73d24dba1f0035fbbf014d2c36828fc1bf9c88f84093e57d315935/charset_normalizer-3.4.7-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:effc3f449787117233702311a1b7d8f59cba9ced946ba727bdc329ec69028e24", size = 330133, upload-time = "2026-04-02T09:27:29.474Z" },
+    { url = "https://files.pythonhosted.org/packages/8d/da/96975ddb11f8e977f706f45cddd8540fd8242f71ecdb5d18a80723dcf62c/charset_normalizer-3.4.7-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:fbccdc05410c9ee21bbf16a35f4c1d16123dcdeb8a1d38f33654fa21d0234f79", size = 216257, upload-time = "2026-04-02T09:27:30.793Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/e8/1d63bf8ef2d388e95c64b2098f45f84758f6d102a087552da1485912637b/charset_normalizer-3.4.7-cp314-cp314t-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:733784b6d6def852c814bce5f318d25da2ee65dd4839a0718641c696e09a2960", size = 234851, upload-time = "2026-04-02T09:27:32.44Z" },
+    { url = "https://files.pythonhosted.org/packages/9b/40/e5ff04233e70da2681fa43969ad6f66ca5611d7e669be0246c4c7aaf6dc8/charset_normalizer-3.4.7-cp314-cp314t-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:a89c23ef8d2c6b27fd200a42aa4ac72786e7c60d40efdc76e6011260b6e949c4", size = 233393, upload-time = "2026-04-02T09:27:34.03Z" },
+    { url = "https://files.pythonhosted.org/packages/be/c1/06c6c49d5a5450f76899992f1ee40b41d076aee9279b49cf9974d2f313d5/charset_normalizer-3.4.7-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:6c114670c45346afedc0d947faf3c7f701051d2518b943679c8ff88befe14f8e", size = 223251, upload-time = "2026-04-02T09:27:35.369Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/9f/f2ff16fb050946169e3e1f82134d107e5d4ae72647ec8a1b1446c148480f/charset_normalizer-3.4.7-cp314-cp314t-manylinux_2_31_armv7l.whl", hash = "sha256:a180c5e59792af262bf263b21a3c49353f25945d8d9f70628e73de370d55e1e1", size = 206609, upload-time = "2026-04-02T09:27:36.661Z" },
+    { url = "https://files.pythonhosted.org/packages/69/d5/a527c0cd8d64d2eab7459784fb4169a0ac76e5a6fc5237337982fd61347e/charset_normalizer-3.4.7-cp314-cp314t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:3c9a494bc5ec77d43cea229c4f6db1e4d8fe7e1bbffa8b6f0f0032430ff8ab44", size = 220014, upload-time = "2026-04-02T09:27:38.019Z" },
+    { url = "https://files.pythonhosted.org/packages/7e/80/8a7b8104a3e203074dc9aa2c613d4b726c0e136bad1cc734594b02867972/charset_normalizer-3.4.7-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:8d828b6667a32a728a1ad1d93957cdf37489c57b97ae6c4de2860fa749b8fc1e", size = 218979, upload-time = "2026-04-02T09:27:39.37Z" },
+    { url = "https://files.pythonhosted.org/packages/02/9a/b759b503d507f375b2b5c153e4d2ee0a75aa215b7f2489cf314f4541f2c0/charset_normalizer-3.4.7-cp314-cp314t-musllinux_1_2_armv7l.whl", hash = "sha256:cf1493cd8607bec4d8a7b9b004e699fcf8f9103a9284cc94962cb73d20f9d4a3", size = 209238, upload-time = "2026-04-02T09:27:40.722Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/4e/0f3f5d47b86bdb79256e7290b26ac847a2832d9a4033f7eb2cd4bcf4bb5b/charset_normalizer-3.4.7-cp314-cp314t-musllinux_1_2_ppc64le.whl", hash = "sha256:0c96c3b819b5c3e9e165495db84d41914d6894d55181d2d108cc1a69bfc9cce0", size = 236110, upload-time = "2026-04-02T09:27:42.33Z" },
+    { url = "https://files.pythonhosted.org/packages/96/23/bce28734eb3ed2c91dcf93abeb8a5cf393a7b2749725030bb630e554fdd8/charset_normalizer-3.4.7-cp314-cp314t-musllinux_1_2_riscv64.whl", hash = "sha256:752a45dc4a6934060b3b0dab47e04edc3326575f82be64bc4fc293914566503e", size = 219824, upload-time = "2026-04-02T09:27:43.924Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/6f/6e897c6984cc4d41af319b077f2f600fc8214eb2fe2d6bcb79141b882400/charset_normalizer-3.4.7-cp314-cp314t-musllinux_1_2_s390x.whl", hash = "sha256:8778f0c7a52e56f75d12dae53ae320fae900a8b9b4164b981b9c5ce059cd1fcb", size = 233103, upload-time = "2026-04-02T09:27:45.348Z" },
+    { url = "https://files.pythonhosted.org/packages/76/22/ef7bd0fe480a0ae9b656189ec00744b60933f68b4f42a7bb06589f6f576a/charset_normalizer-3.4.7-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:ce3412fbe1e31eb81ea42f4169ed94861c56e643189e1e75f0041f3fe7020abe", size = 225194, upload-time = "2026-04-02T09:27:46.706Z" },
+    { url = "https://files.pythonhosted.org/packages/c5/a7/0e0ab3e0b5bc1219bd80a6a0d4d72ca74d9250cb2382b7c699c147e06017/charset_normalizer-3.4.7-cp314-cp314t-win32.whl", hash = "sha256:c03a41a8784091e67a39648f70c5f97b5b6a37f216896d44d2cdcb82615339a0", size = 159827, upload-time = "2026-04-02T09:27:48.053Z" },
+    { url = "https://files.pythonhosted.org/packages/7a/1d/29d32e0fb40864b1f878c7f5a0b343ae676c6e2b271a2d55cc3a152391da/charset_normalizer-3.4.7-cp314-cp314t-win_amd64.whl", hash = "sha256:03853ed82eeebbce3c2abfdbc98c96dc205f32a79627688ac9a27370ea61a49c", size = 174168, upload-time = "2026-04-02T09:27:49.795Z" },
+    { url = "https://files.pythonhosted.org/packages/de/32/d92444ad05c7a6e41fb2036749777c163baf7a0301a040cb672d6b2b1ae9/charset_normalizer-3.4.7-cp314-cp314t-win_arm64.whl", hash = "sha256:c35abb8bfff0185efac5878da64c45dafd2b37fb0383add1be155a763c1f083d", size = 153018, upload-time = "2026-04-02T09:27:51.116Z" },
+    { url = "https://files.pythonhosted.org/packages/db/8f/61959034484a4a7c527811f4721e75d02d653a35afb0b6054474d8185d4c/charset_normalizer-3.4.7-py3-none-any.whl", hash = "sha256:3dce51d0f5e7951f8bb4900c257dad282f49190fdbebecd4ba99bcc41fef404d", size = 61958, upload-time = "2026-04-02T09:28:37.794Z" },
+]
+
+[[package]]
+name = "colorama"
+version = "0.4.6"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d8/53/6f443c9a4a8358a93a6792e2acffb9d9d5cb0a5cfd8802644b7b1c9a02e4/colorama-0.4.6.tar.gz", hash = "sha256:08695f5cb7ed6e0531a20572697297273c47b8cae5a63ffc6d6ed5c201be6e44", size = 27697, upload-time = "2022-10-25T02:36:22.414Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d1/d6/3965ed04c63042e047cb6a3e6ed1a63a35087b6a609aa3a15ed8ac56c221/colorama-0.4.6-py2.py3-none-any.whl", hash = "sha256:4f1d9991f5acc0ca119f9d443620b77f9d6b33703e51011c16baf57afb285fc6", size = 25335, upload-time = "2022-10-25T02:36:20.889Z" },
+]
+
+[[package]]
+name = "cyclonedx-python-lib"
+version = "11.7.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "license-expression" },
+    { name = "packageurl-python" },
+    { name = "py-serializable" },
+    { name = "sortedcontainers" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/21/0d/64f02d3fd9c116d6f50a540d04d1e4f2e3c487f5062d2db53733ddb25917/cyclonedx_python_lib-11.7.0.tar.gz", hash = "sha256:fb1bc3dedfa31208444dbd743007f478ab6984010a184e5bd466bffd969e936e", size = 1411174, upload-time = "2026-03-17T15:19:16.606Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/30/09/fe0e3bc32bd33707c519b102fc064ad2a2ce5a1b53e2be38b86936b476b1/cyclonedx_python_lib-11.7.0-py3-none-any.whl", hash = "sha256:02fa4f15ddbba21ac9093039f8137c0d1813af7fe88b760c5dcd3311a8da2178", size = 513041, upload-time = "2026-03-17T15:19:14.369Z" },
+]
+
+[[package]]
+name = "defusedxml"
+version = "0.7.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/0f/d5/c66da9b79e5bdb124974bfe172b4daf3c984ebd9c2a06e2b8a4dc7331c72/defusedxml-0.7.1.tar.gz", hash = "sha256:1bb3032db185915b62d7c6209c5a8792be6a32ab2fedacc84e01b52c51aa3e69", size = 75520, upload-time = "2021-03-08T10:59:26.269Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/07/6c/aa3f2f849e01cb6a001cd8554a88d4c77c5c1a31c95bdf1cf9301e6d9ef4/defusedxml-0.7.1-py2.py3-none-any.whl", hash = "sha256:a352e7e428770286cc899e2542b6cdaedb2b4953ff269a210103ec58f6198a61", size = 25604, upload-time = "2021-03-08T10:59:24.45Z" },
+]
+
+[[package]]
+name = "execnet"
+version = "2.1.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/bf/89/780e11f9588d9e7128a3f87788354c7946a9cbb1401ad38a48c4db9a4f07/execnet-2.1.2.tar.gz", hash = "sha256:63d83bfdd9a23e35b9c6a3261412324f964c2ec8dcd8d3c6916ee9373e0befcd", size = 166622, upload-time = "2025-11-12T09:56:37.75Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ab/84/02fc1827e8cdded4aa65baef11296a9bbe595c474f0d6d758af082d849fd/execnet-2.1.2-py3-none-any.whl", hash = "sha256:67fba928dd5a544b783f6056f449e5e3931a5c378b128bc18501f7ea79e296ec", size = 40708, upload-time = "2025-11-12T09:56:36.333Z" },
+]
+
+[[package]]
+name = "filelock"
+version = "3.25.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/94/b8/00651a0f559862f3bb7d6f7477b192afe3f583cc5e26403b44e59a55ab34/filelock-3.25.2.tar.gz", hash = "sha256:b64ece2b38f4ca29dd3e810287aa8c48182bbecd1ae6e9ae126c9b35f1382694", size = 40480, upload-time = "2026-03-11T20:45:38.487Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a4/a5/842ae8f0c08b61d6484b52f99a03510a3a72d23141942d216ebe81fefbce/filelock-3.25.2-py3-none-any.whl", hash = "sha256:ca8afb0da15f229774c9ad1b455ed96e85a81373065fb10446672f64444ddf70", size = 26759, upload-time = "2026-03-11T20:45:37.437Z" },
+]
+
+[[package]]
+name = "frozenlist"
+version = "1.8.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/2d/f5/c831fac6cc817d26fd54c7eaccd04ef7e0288806943f7cc5bbf69f3ac1f0/frozenlist-1.8.0.tar.gz", hash = "sha256:3ede829ed8d842f6cd48fc7081d7a41001a56f1f38603f9d49bf3020d59a31ad", size = 45875, upload-time = "2025-10-06T05:38:17.865Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f1/c8/85da824b7e7b9b6e7f7705b2ecaf9591ba6f79c1177f324c2735e41d36a2/frozenlist-1.8.0-cp314-cp314-macosx_10_13_universal2.whl", hash = "sha256:cee686f1f4cadeb2136007ddedd0aaf928ab95216e7691c63e50a8ec066336d0", size = 86127, upload-time = "2025-10-06T05:37:08.438Z" },
+    { url = "https://files.pythonhosted.org/packages/8e/e8/a1185e236ec66c20afd72399522f142c3724c785789255202d27ae992818/frozenlist-1.8.0-cp314-cp314-macosx_10_13_x86_64.whl", hash = "sha256:119fb2a1bd47307e899c2fac7f28e85b9a543864df47aa7ec9d3c1b4545f096f", size = 49698, upload-time = "2025-10-06T05:37:09.48Z" },
+    { url = "https://files.pythonhosted.org/packages/a1/93/72b1736d68f03fda5fdf0f2180fb6caaae3894f1b854d006ac61ecc727ee/frozenlist-1.8.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:4970ece02dbc8c3a92fcc5228e36a3e933a01a999f7094ff7c23fbd2beeaa67c", size = 49749, upload-time = "2025-10-06T05:37:10.569Z" },
+    { url = "https://files.pythonhosted.org/packages/a7/b2/fabede9fafd976b991e9f1b9c8c873ed86f202889b864756f240ce6dd855/frozenlist-1.8.0-cp314-cp314-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:cba69cb73723c3f329622e34bdbf5ce1f80c21c290ff04256cff1cd3c2036ed2", size = 231298, upload-time = "2025-10-06T05:37:11.993Z" },
+    { url = "https://files.pythonhosted.org/packages/3a/3b/d9b1e0b0eed36e70477ffb8360c49c85c8ca8ef9700a4e6711f39a6e8b45/frozenlist-1.8.0-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:778a11b15673f6f1df23d9586f83c4846c471a8af693a22e066508b77d201ec8", size = 232015, upload-time = "2025-10-06T05:37:13.194Z" },
+    { url = "https://files.pythonhosted.org/packages/dc/94/be719d2766c1138148564a3960fc2c06eb688da592bdc25adcf856101be7/frozenlist-1.8.0-cp314-cp314-manylinux2014_armv7l.manylinux_2_17_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:0325024fe97f94c41c08872db482cf8ac4800d80e79222c6b0b7b162d5b13686", size = 225038, upload-time = "2025-10-06T05:37:14.577Z" },
+    { url = "https://files.pythonhosted.org/packages/e4/09/6712b6c5465f083f52f50cf74167b92d4ea2f50e46a9eea0523d658454ae/frozenlist-1.8.0-cp314-cp314-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:97260ff46b207a82a7567b581ab4190bd4dfa09f4db8a8b49d1a958f6aa4940e", size = 240130, upload-time = "2025-10-06T05:37:15.781Z" },
+    { url = "https://files.pythonhosted.org/packages/f8/d4/cd065cdcf21550b54f3ce6a22e143ac9e4836ca42a0de1022da8498eac89/frozenlist-1.8.0-cp314-cp314-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:54b2077180eb7f83dd52c40b2750d0a9f175e06a42e3213ce047219de902717a", size = 242845, upload-time = "2025-10-06T05:37:17.037Z" },
+    { url = "https://files.pythonhosted.org/packages/62/c3/f57a5c8c70cd1ead3d5d5f776f89d33110b1addae0ab010ad774d9a44fb9/frozenlist-1.8.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:2f05983daecab868a31e1da44462873306d3cbfd76d1f0b5b69c473d21dbb128", size = 229131, upload-time = "2025-10-06T05:37:18.221Z" },
+    { url = "https://files.pythonhosted.org/packages/6c/52/232476fe9cb64f0742f3fde2b7d26c1dac18b6d62071c74d4ded55e0ef94/frozenlist-1.8.0-cp314-cp314-musllinux_1_2_armv7l.whl", hash = "sha256:33f48f51a446114bc5d251fb2954ab0164d5be02ad3382abcbfe07e2531d650f", size = 240542, upload-time = "2025-10-06T05:37:19.771Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/85/07bf3f5d0fb5414aee5f47d33c6f5c77bfe49aac680bfece33d4fdf6a246/frozenlist-1.8.0-cp314-cp314-musllinux_1_2_ppc64le.whl", hash = "sha256:154e55ec0655291b5dd1b8731c637ecdb50975a2ae70c606d100750a540082f7", size = 237308, upload-time = "2025-10-06T05:37:20.969Z" },
+    { url = "https://files.pythonhosted.org/packages/11/99/ae3a33d5befd41ac0ca2cc7fd3aa707c9c324de2e89db0e0f45db9a64c26/frozenlist-1.8.0-cp314-cp314-musllinux_1_2_s390x.whl", hash = "sha256:4314debad13beb564b708b4a496020e5306c7333fa9a3ab90374169a20ffab30", size = 238210, upload-time = "2025-10-06T05:37:22.252Z" },
+    { url = "https://files.pythonhosted.org/packages/b2/60/b1d2da22f4970e7a155f0adde9b1435712ece01b3cd45ba63702aea33938/frozenlist-1.8.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:073f8bf8becba60aa931eb3bc420b217bb7d5b8f4750e6f8b3be7f3da85d38b7", size = 231972, upload-time = "2025-10-06T05:37:23.5Z" },
+    { url = "https://files.pythonhosted.org/packages/3f/ab/945b2f32de889993b9c9133216c068b7fcf257d8595a0ac420ac8677cab0/frozenlist-1.8.0-cp314-cp314-win32.whl", hash = "sha256:bac9c42ba2ac65ddc115d930c78d24ab8d4f465fd3fc473cdedfccadb9429806", size = 40536, upload-time = "2025-10-06T05:37:25.581Z" },
+    { url = "https://files.pythonhosted.org/packages/59/ad/9caa9b9c836d9ad6f067157a531ac48b7d36499f5036d4141ce78c230b1b/frozenlist-1.8.0-cp314-cp314-win_amd64.whl", hash = "sha256:3e0761f4d1a44f1d1a47996511752cf3dcec5bbdd9cc2b4fe595caf97754b7a0", size = 44330, upload-time = "2025-10-06T05:37:26.928Z" },
+    { url = "https://files.pythonhosted.org/packages/82/13/e6950121764f2676f43534c555249f57030150260aee9dcf7d64efda11dd/frozenlist-1.8.0-cp314-cp314-win_arm64.whl", hash = "sha256:d1eaff1d00c7751b7c6662e9c5ba6eb2c17a2306ba5e2a37f24ddf3cc953402b", size = 40627, upload-time = "2025-10-06T05:37:28.075Z" },
+    { url = "https://files.pythonhosted.org/packages/c0/c7/43200656ecc4e02d3f8bc248df68256cd9572b3f0017f0a0c4e93440ae23/frozenlist-1.8.0-cp314-cp314t-macosx_10_13_universal2.whl", hash = "sha256:d3bb933317c52d7ea5004a1c442eef86f426886fba134ef8cf4226ea6ee1821d", size = 89238, upload-time = "2025-10-06T05:37:29.373Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/29/55c5f0689b9c0fb765055629f472c0de484dcaf0acee2f7707266ae3583c/frozenlist-1.8.0-cp314-cp314t-macosx_10_13_x86_64.whl", hash = "sha256:8009897cdef112072f93a0efdce29cd819e717fd2f649ee3016efd3cd885a7ed", size = 50738, upload-time = "2025-10-06T05:37:30.792Z" },
+    { url = "https://files.pythonhosted.org/packages/ba/7d/b7282a445956506fa11da8c2db7d276adcbf2b17d8bb8407a47685263f90/frozenlist-1.8.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:2c5dcbbc55383e5883246d11fd179782a9d07a986c40f49abe89ddf865913930", size = 51739, upload-time = "2025-10-06T05:37:32.127Z" },
+    { url = "https://files.pythonhosted.org/packages/62/1c/3d8622e60d0b767a5510d1d3cf21065b9db874696a51ea6d7a43180a259c/frozenlist-1.8.0-cp314-cp314t-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:39ecbc32f1390387d2aa4f5a995e465e9e2f79ba3adcac92d68e3e0afae6657c", size = 284186, upload-time = "2025-10-06T05:37:33.21Z" },
+    { url = "https://files.pythonhosted.org/packages/2d/14/aa36d5f85a89679a85a1d44cd7a6657e0b1c75f61e7cad987b203d2daca8/frozenlist-1.8.0-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:92db2bf818d5cc8d9c1f1fc56b897662e24ea5adb36ad1f1d82875bd64e03c24", size = 292196, upload-time = "2025-10-06T05:37:36.107Z" },
+    { url = "https://files.pythonhosted.org/packages/05/23/6bde59eb55abd407d34f77d39a5126fb7b4f109a3f611d3929f14b700c66/frozenlist-1.8.0-cp314-cp314t-manylinux2014_armv7l.manylinux_2_17_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:2dc43a022e555de94c3b68a4ef0b11c4f747d12c024a520c7101709a2144fb37", size = 273830, upload-time = "2025-10-06T05:37:37.663Z" },
+    { url = "https://files.pythonhosted.org/packages/d2/3f/22cff331bfad7a8afa616289000ba793347fcd7bc275f3b28ecea2a27909/frozenlist-1.8.0-cp314-cp314t-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:cb89a7f2de3602cfed448095bab3f178399646ab7c61454315089787df07733a", size = 294289, upload-time = "2025-10-06T05:37:39.261Z" },
+    { url = "https://files.pythonhosted.org/packages/a4/89/5b057c799de4838b6c69aa82b79705f2027615e01be996d2486a69ca99c4/frozenlist-1.8.0-cp314-cp314t-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:33139dc858c580ea50e7e60a1b0ea003efa1fd42e6ec7fdbad78fff65fad2fd2", size = 300318, upload-time = "2025-10-06T05:37:43.213Z" },
+    { url = "https://files.pythonhosted.org/packages/30/de/2c22ab3eb2a8af6d69dc799e48455813bab3690c760de58e1bf43b36da3e/frozenlist-1.8.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:168c0969a329b416119507ba30b9ea13688fafffac1b7822802537569a1cb0ef", size = 282814, upload-time = "2025-10-06T05:37:45.337Z" },
+    { url = "https://files.pythonhosted.org/packages/59/f7/970141a6a8dbd7f556d94977858cfb36fa9b66e0892c6dd780d2219d8cd8/frozenlist-1.8.0-cp314-cp314t-musllinux_1_2_armv7l.whl", hash = "sha256:28bd570e8e189d7f7b001966435f9dac6718324b5be2990ac496cf1ea9ddb7fe", size = 291762, upload-time = "2025-10-06T05:37:46.657Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/15/ca1adae83a719f82df9116d66f5bb28bb95557b3951903d39135620ef157/frozenlist-1.8.0-cp314-cp314t-musllinux_1_2_ppc64le.whl", hash = "sha256:b2a095d45c5d46e5e79ba1e5b9cb787f541a8dee0433836cea4b96a2c439dcd8", size = 289470, upload-time = "2025-10-06T05:37:47.946Z" },
+    { url = "https://files.pythonhosted.org/packages/ac/83/dca6dc53bf657d371fbc88ddeb21b79891e747189c5de990b9dfff2ccba1/frozenlist-1.8.0-cp314-cp314t-musllinux_1_2_s390x.whl", hash = "sha256:eab8145831a0d56ec9c4139b6c3e594c7a83c2c8be25d5bcf2d86136a532287a", size = 289042, upload-time = "2025-10-06T05:37:49.499Z" },
+    { url = "https://files.pythonhosted.org/packages/96/52/abddd34ca99be142f354398700536c5bd315880ed0a213812bc491cff5e4/frozenlist-1.8.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:974b28cf63cc99dfb2188d8d222bc6843656188164848c4f679e63dae4b0708e", size = 283148, upload-time = "2025-10-06T05:37:50.745Z" },
+    { url = "https://files.pythonhosted.org/packages/af/d3/76bd4ed4317e7119c2b7f57c3f6934aba26d277acc6309f873341640e21f/frozenlist-1.8.0-cp314-cp314t-win32.whl", hash = "sha256:342c97bf697ac5480c0a7ec73cd700ecfa5a8a40ac923bd035484616efecc2df", size = 44676, upload-time = "2025-10-06T05:37:52.222Z" },
+    { url = "https://files.pythonhosted.org/packages/89/76/c615883b7b521ead2944bb3480398cbb07e12b7b4e4d073d3752eb721558/frozenlist-1.8.0-cp314-cp314t-win_amd64.whl", hash = "sha256:06be8f67f39c8b1dc671f5d83aaefd3358ae5cdcf8314552c57e7ed3e6475bdd", size = 49451, upload-time = "2025-10-06T05:37:53.425Z" },
+    { url = "https://files.pythonhosted.org/packages/e0/a3/5982da14e113d07b325230f95060e2169f5311b1017ea8af2a29b374c289/frozenlist-1.8.0-cp314-cp314t-win_arm64.whl", hash = "sha256:102e6314ca4da683dca92e3b1355490fed5f313b768500084fbe6371fddfdb79", size = 42507, upload-time = "2025-10-06T05:37:54.513Z" },
+    { url = "https://files.pythonhosted.org/packages/9a/9a/e35b4a917281c0b8419d4207f4334c8e8c5dbf4f3f5f9ada73958d937dcc/frozenlist-1.8.0-py3-none-any.whl", hash = "sha256:0c18a16eab41e82c295618a77502e17b195883241c563b00f0aa5106fc4eaa0d", size = 13409, upload-time = "2025-10-06T05:38:16.721Z" },
+]
+
+[[package]]
+name = "idna"
+version = "3.11"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/6f/6d/0703ccc57f3a7233505399edb88de3cbd678da106337b9fcde432b65ed60/idna-3.11.tar.gz", hash = "sha256:795dafcc9c04ed0c1fb032c2aa73654d8e8c5023a7df64a53f39190ada629902", size = 194582, upload-time = "2025-10-12T14:55:20.501Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/0e/61/66938bbb5fc52dbdf84594873d5b51fb1f7c7794e9c0f5bd885f30bc507b/idna-3.11-py3-none-any.whl", hash = "sha256:771a87f49d9defaf64091e6e6fe9c18d4833f140bd19464795bc32d966ca37ea", size = 71008, upload-time = "2025-10-12T14:55:18.883Z" },
+]
+
+[[package]]
+name = "iniconfig"
+version = "2.3.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/72/34/14ca021ce8e5dfedc35312d08ba8bf51fdd999c576889fc2c24cb97f4f10/iniconfig-2.3.0.tar.gz", hash = "sha256:c76315c77db068650d49c5b56314774a7804df16fee4402c1f19d6d15d8c4730", size = 20503, upload-time = "2025-10-18T21:55:43.219Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/cb/b1/3846dd7f199d53cb17f49cba7e651e9ce294d8497c8c150530ed11865bb8/iniconfig-2.3.0-py3-none-any.whl", hash = "sha256:f631c04d2c48c52b84d0d0549c99ff3859c98df65b3101406327ecc7d53fbf12", size = 7484, upload-time = "2025-10-18T21:55:41.639Z" },
+]
+
+[[package]]
+name = "license-expression"
+version = "30.4.4"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "boolean-py" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/40/71/d89bb0e71b1415453980fd32315f2a037aad9f7f70f695c7cec7035feb13/license_expression-30.4.4.tar.gz", hash = "sha256:73448f0aacd8d0808895bdc4b2c8e01a8d67646e4188f887375398c761f340fd", size = 186402, upload-time = "2025-07-22T11:13:32.17Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/af/40/791891d4c0c4dab4c5e187c17261cedc26285fd41541577f900470a45a4d/license_expression-30.4.4-py3-none-any.whl", hash = "sha256:421788fdcadb41f049d2dc934ce666626265aeccefddd25e162a26f23bcbf8a4", size = 120615, upload-time = "2025-07-22T11:13:31.217Z" },
+]
+
+[[package]]
+name = "magic-filter"
+version = "1.0.12"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/e6/08/da7c2cc7398cc0376e8da599d6330a437c01d3eace2f2365f300e0f3f758/magic_filter-1.0.12.tar.gz", hash = "sha256:4751d0b579a5045d1dc250625c4c508c18c3def5ea6afaf3957cb4530d03f7f9", size = 11071, upload-time = "2023-10-01T12:33:19.006Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/cc/75/f620449f0056eff0ec7c1b1e088f71068eb4e47a46eb54f6c065c6ad7675/magic_filter-1.0.12-py3-none-any.whl", hash = "sha256:e5929e544f310c2b1f154318db8c5cdf544dd658efa998172acd2e4ba0f6c6a6", size = 11335, upload-time = "2023-10-01T12:33:17.711Z" },
+]
+
+[[package]]
+name = "markdown-it-py"
+version = "4.0.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "mdurl" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/5b/f5/4ec618ed16cc4f8fb3b701563655a69816155e79e24a17b651541804721d/markdown_it_py-4.0.0.tar.gz", hash = "sha256:cb0a2b4aa34f932c007117b194e945bd74e0ec24133ceb5bac59009cda1cb9f3", size = 73070, upload-time = "2025-08-11T12:57:52.854Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/94/54/e7d793b573f298e1c9013b8c4dade17d481164aa517d1d7148619c2cedbf/markdown_it_py-4.0.0-py3-none-any.whl", hash = "sha256:87327c59b172c5011896038353a81343b6754500a08cd7a4973bb48c6d578147", size = 87321, upload-time = "2025-08-11T12:57:51.923Z" },
+]
+
+[[package]]
+name = "mdurl"
+version = "0.1.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d6/54/cfe61301667036ec958cb99bd3efefba235e65cdeb9c84d24a8293ba1d90/mdurl-0.1.2.tar.gz", hash = "sha256:bb413d29f5eea38f31dd4754dd7377d4465116fb207585f97bf925588687c1ba", size = 8729, upload-time = "2022-08-14T12:40:10.846Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b3/38/89ba8ad64ae25be8de66a6d463314cf1eb366222074cfda9ee839c56a4b4/mdurl-0.1.2-py3-none-any.whl", hash = "sha256:84008a41e51615a49fc9966191ff91509e3c40b939176e643fd50a5c2196b8f8", size = 9979, upload-time = "2022-08-14T12:40:09.779Z" },
+]
+
+[[package]]
+name = "msgpack"
+version = "1.1.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/4d/f2/bfb55a6236ed8725a96b0aa3acbd0ec17588e6a2c3b62a93eb513ed8783f/msgpack-1.1.2.tar.gz", hash = "sha256:3b60763c1373dd60f398488069bcdc703cd08a711477b5d480eecc9f9626f47e", size = 173581, upload-time = "2025-10-08T09:15:56.596Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/22/71/201105712d0a2ff07b7873ed3c220292fb2ea5120603c00c4b634bcdafb3/msgpack-1.1.2-cp314-cp314-macosx_10_13_x86_64.whl", hash = "sha256:e23ce8d5f7aa6ea6d2a2b326b4ba46c985dbb204523759984430db7114f8aa00", size = 81127, upload-time = "2025-10-08T09:15:24.408Z" },
+    { url = "https://files.pythonhosted.org/packages/1b/9f/38ff9e57a2eade7bf9dfee5eae17f39fc0e998658050279cbb14d97d36d9/msgpack-1.1.2-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:6c15b7d74c939ebe620dd8e559384be806204d73b4f9356320632d783d1f7939", size = 84981, upload-time = "2025-10-08T09:15:25.812Z" },
+    { url = "https://files.pythonhosted.org/packages/8e/a9/3536e385167b88c2cc8f4424c49e28d49a6fc35206d4a8060f136e71f94c/msgpack-1.1.2-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:99e2cb7b9031568a2a5c73aa077180f93dd2e95b4f8d3b8e14a73ae94a9e667e", size = 411885, upload-time = "2025-10-08T09:15:27.22Z" },
+    { url = "https://files.pythonhosted.org/packages/2f/40/dc34d1a8d5f1e51fc64640b62b191684da52ca469da9cd74e84936ffa4a6/msgpack-1.1.2-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:180759d89a057eab503cf62eeec0aa61c4ea1200dee709f3a8e9397dbb3b6931", size = 419658, upload-time = "2025-10-08T09:15:28.4Z" },
+    { url = "https://files.pythonhosted.org/packages/3b/ef/2b92e286366500a09a67e03496ee8b8ba00562797a52f3c117aa2b29514b/msgpack-1.1.2-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:04fb995247a6e83830b62f0b07bf36540c213f6eac8e851166d8d86d83cbd014", size = 403290, upload-time = "2025-10-08T09:15:29.764Z" },
+    { url = "https://files.pythonhosted.org/packages/78/90/e0ea7990abea5764e4655b8177aa7c63cdfa89945b6e7641055800f6c16b/msgpack-1.1.2-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:8e22ab046fa7ede9e36eeb4cfad44d46450f37bb05d5ec482b02868f451c95e2", size = 415234, upload-time = "2025-10-08T09:15:31.022Z" },
+    { url = "https://files.pythonhosted.org/packages/72/4e/9390aed5db983a2310818cd7d3ec0aecad45e1f7007e0cda79c79507bb0d/msgpack-1.1.2-cp314-cp314-win32.whl", hash = "sha256:80a0ff7d4abf5fecb995fcf235d4064b9a9a8a40a3ab80999e6ac1e30b702717", size = 66391, upload-time = "2025-10-08T09:15:32.265Z" },
+    { url = "https://files.pythonhosted.org/packages/6e/f1/abd09c2ae91228c5f3998dbd7f41353def9eac64253de3c8105efa2082f7/msgpack-1.1.2-cp314-cp314-win_amd64.whl", hash = "sha256:9ade919fac6a3e7260b7f64cea89df6bec59104987cbea34d34a2fa15d74310b", size = 73787, upload-time = "2025-10-08T09:15:33.219Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/b0/9d9f667ab48b16ad4115c1935d94023b82b3198064cb84a123e97f7466c1/msgpack-1.1.2-cp314-cp314-win_arm64.whl", hash = "sha256:59415c6076b1e30e563eb732e23b994a61c159cec44deaf584e5cc1dd662f2af", size = 66453, upload-time = "2025-10-08T09:15:34.225Z" },
+    { url = "https://files.pythonhosted.org/packages/16/67/93f80545eb1792b61a217fa7f06d5e5cb9e0055bed867f43e2b8e012e137/msgpack-1.1.2-cp314-cp314t-macosx_10_13_x86_64.whl", hash = "sha256:897c478140877e5307760b0ea66e0932738879e7aa68144d9b78ea4c8302a84a", size = 85264, upload-time = "2025-10-08T09:15:35.61Z" },
+    { url = "https://files.pythonhosted.org/packages/87/1c/33c8a24959cf193966ef11a6f6a2995a65eb066bd681fd085afd519a57ce/msgpack-1.1.2-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:a668204fa43e6d02f89dbe79a30b0d67238d9ec4c5bd8a940fc3a004a47b721b", size = 89076, upload-time = "2025-10-08T09:15:36.619Z" },
+    { url = "https://files.pythonhosted.org/packages/fc/6b/62e85ff7193663fbea5c0254ef32f0c77134b4059f8da89b958beb7696f3/msgpack-1.1.2-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:5559d03930d3aa0f3aacb4c42c776af1a2ace2611871c84a75afe436695e6245", size = 435242, upload-time = "2025-10-08T09:15:37.647Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/47/5c74ecb4cc277cf09f64e913947871682ffa82b3b93c8dad68083112f412/msgpack-1.1.2-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:70c5a7a9fea7f036b716191c29047374c10721c389c21e9ffafad04df8c52c90", size = 432509, upload-time = "2025-10-08T09:15:38.794Z" },
+    { url = "https://files.pythonhosted.org/packages/24/a4/e98ccdb56dc4e98c929a3f150de1799831c0a800583cde9fa022fa90602d/msgpack-1.1.2-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:f2cb069d8b981abc72b41aea1c580ce92d57c673ec61af4c500153a626cb9e20", size = 415957, upload-time = "2025-10-08T09:15:40.238Z" },
+    { url = "https://files.pythonhosted.org/packages/da/28/6951f7fb67bc0a4e184a6b38ab71a92d9ba58080b27a77d3e2fb0be5998f/msgpack-1.1.2-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:d62ce1f483f355f61adb5433ebfd8868c5f078d1a52d042b0a998682b4fa8c27", size = 422910, upload-time = "2025-10-08T09:15:41.505Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/03/42106dcded51f0a0b5284d3ce30a671e7bd3f7318d122b2ead66ad289fed/msgpack-1.1.2-cp314-cp314t-win32.whl", hash = "sha256:1d1418482b1ee984625d88aa9585db570180c286d942da463533b238b98b812b", size = 75197, upload-time = "2025-10-08T09:15:42.954Z" },
+    { url = "https://files.pythonhosted.org/packages/15/86/d0071e94987f8db59d4eeb386ddc64d0bb9b10820a8d82bcd3e53eeb2da6/msgpack-1.1.2-cp314-cp314t-win_amd64.whl", hash = "sha256:5a46bf7e831d09470ad92dff02b8b1ac92175ca36b087f904a0519857c6be3ff", size = 85772, upload-time = "2025-10-08T09:15:43.954Z" },
+    { url = "https://files.pythonhosted.org/packages/81/f2/08ace4142eb281c12701fc3b93a10795e4d4dc7f753911d836675050f886/msgpack-1.1.2-cp314-cp314t-win_arm64.whl", hash = "sha256:d99ef64f349d5ec3293688e91486c5fdb925ed03807f64d98d205d2713c60b46", size = 70868, upload-time = "2025-10-08T09:15:44.959Z" },
+]
+
+[[package]]
+name = "multidict"
+version = "6.7.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/1a/c2/c2d94cbe6ac1753f3fc980da97b3d930efe1da3af3c9f5125354436c073d/multidict-6.7.1.tar.gz", hash = "sha256:ec6652a1bee61c53a3e5776b6049172c53b6aaba34f18c9ad04f82712bac623d", size = 102010, upload-time = "2026-01-26T02:46:45.979Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/91/cc/db74228a8be41884a567e88a62fd589a913708fcf180d029898c17a9a371/multidict-6.7.1-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:8f333ec9c5eb1b7105e3b84b53141e66ca05a19a605368c55450b6ba208cb9ee", size = 75190, upload-time = "2026-01-26T02:45:10.651Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/22/492f2246bb5b534abd44804292e81eeaf835388901f0c574bac4eeec73c5/multidict-6.7.1-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:a407f13c188f804c759fc6a9f88286a565c242a76b27626594c133b82883b5c2", size = 44486, upload-time = "2026-01-26T02:45:11.938Z" },
+    { url = "https://files.pythonhosted.org/packages/f1/4f/733c48f270565d78b4544f2baddc2fb2a245e5a8640254b12c36ac7ac68e/multidict-6.7.1-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:0e161ddf326db5577c3a4cc2d8648f81456e8a20d40415541587a71620d7a7d1", size = 43219, upload-time = "2026-01-26T02:45:14.346Z" },
+    { url = "https://files.pythonhosted.org/packages/24/bb/2c0c2287963f4259c85e8bcbba9182ced8d7fca65c780c38e99e61629d11/multidict-6.7.1-cp314-cp314-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:1e3a8bb24342a8201d178c3b4984c26ba81a577c80d4d525727427460a50c22d", size = 245132, upload-time = "2026-01-26T02:45:15.712Z" },
+    { url = "https://files.pythonhosted.org/packages/a7/f9/44d4b3064c65079d2467888794dea218d1601898ac50222ab8a9a8094460/multidict-6.7.1-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:97231140a50f5d447d3164f994b86a0bed7cd016e2682f8650d6a9158e14fd31", size = 252420, upload-time = "2026-01-26T02:45:17.293Z" },
+    { url = "https://files.pythonhosted.org/packages/8b/13/78f7275e73fa17b24c9a51b0bd9d73ba64bb32d0ed51b02a746eb876abe7/multidict-6.7.1-cp314-cp314-manylinux2014_armv7l.manylinux_2_17_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:6b10359683bd8806a200fd2909e7c8ca3a7b24ec1d8132e483d58e791d881048", size = 233510, upload-time = "2026-01-26T02:45:19.356Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/25/8167187f62ae3cbd52da7893f58cb036b47ea3fb67138787c76800158982/multidict-6.7.1-cp314-cp314-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:283ddac99f7ac25a4acadbf004cb5ae34480bbeb063520f70ce397b281859362", size = 264094, upload-time = "2026-01-26T02:45:20.834Z" },
+    { url = "https://files.pythonhosted.org/packages/a1/e7/69a3a83b7b030cf283fb06ce074a05a02322359783424d7edf0f15fe5022/multidict-6.7.1-cp314-cp314-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:538cec1e18c067d0e6103aa9a74f9e832904c957adc260e61cd9d8cf0c3b3d37", size = 260786, upload-time = "2026-01-26T02:45:22.818Z" },
+    { url = "https://files.pythonhosted.org/packages/fe/3b/8ec5074bcfc450fe84273713b4b0a0dd47c0249358f5d82eb8104ffe2520/multidict-6.7.1-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:7eee46ccb30ff48a1e35bb818cc90846c6be2b68240e42a78599166722cea709", size = 248483, upload-time = "2026-01-26T02:45:24.368Z" },
+    { url = "https://files.pythonhosted.org/packages/48/5a/d5a99e3acbca0e29c5d9cba8f92ceb15dce78bab963b308ae692981e3a5d/multidict-6.7.1-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:fa263a02f4f2dd2d11a7b1bb4362aa7cb1049f84a9235d31adf63f30143469a0", size = 248403, upload-time = "2026-01-26T02:45:25.982Z" },
+    { url = "https://files.pythonhosted.org/packages/35/48/e58cd31f6c7d5102f2a4bf89f96b9cf7e00b6c6f3d04ecc44417c00a5a3c/multidict-6.7.1-cp314-cp314-musllinux_1_2_armv7l.whl", hash = "sha256:2e1425e2f99ec5bd36c15a01b690a1a2456209c5deed58f95469ffb46039ccbb", size = 240315, upload-time = "2026-01-26T02:45:27.487Z" },
+    { url = "https://files.pythonhosted.org/packages/94/33/1cd210229559cb90b6786c30676bb0c58249ff42f942765f88793b41fdce/multidict-6.7.1-cp314-cp314-musllinux_1_2_i686.whl", hash = "sha256:497394b3239fc6f0e13a78a3e1b61296e72bf1c5f94b4c4eb80b265c37a131cd", size = 245528, upload-time = "2026-01-26T02:45:28.991Z" },
+    { url = "https://files.pythonhosted.org/packages/64/f2/6e1107d226278c876c783056b7db43d800bb64c6131cec9c8dfb6903698e/multidict-6.7.1-cp314-cp314-musllinux_1_2_ppc64le.whl", hash = "sha256:233b398c29d3f1b9676b4b6f75c518a06fcb2ea0b925119fb2c1bc35c05e1601", size = 258784, upload-time = "2026-01-26T02:45:30.503Z" },
+    { url = "https://files.pythonhosted.org/packages/4d/c1/11f664f14d525e4a1b5327a82d4de61a1db604ab34c6603bb3c2cc63ad34/multidict-6.7.1-cp314-cp314-musllinux_1_2_s390x.whl", hash = "sha256:93b1818e4a6e0930454f0f2af7dfce69307ca03cdcfb3739bf4d91241967b6c1", size = 251980, upload-time = "2026-01-26T02:45:32.603Z" },
+    { url = "https://files.pythonhosted.org/packages/e1/9f/75a9ac888121d0c5bbd4ecf4eead45668b1766f6baabfb3b7f66a410e231/multidict-6.7.1-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:f33dc2a3abe9249ea5d8360f969ec7f4142e7ac45ee7014d8f8d5acddf178b7b", size = 243602, upload-time = "2026-01-26T02:45:34.043Z" },
+    { url = "https://files.pythonhosted.org/packages/9a/e7/50bf7b004cc8525d80dbbbedfdc7aed3e4c323810890be4413e589074032/multidict-6.7.1-cp314-cp314-win32.whl", hash = "sha256:3ab8b9d8b75aef9df299595d5388b14530839f6422333357af1339443cff777d", size = 40930, upload-time = "2026-01-26T02:45:36.278Z" },
+    { url = "https://files.pythonhosted.org/packages/e0/bf/52f25716bbe93745595800f36fb17b73711f14da59ed0bb2eba141bc9f0f/multidict-6.7.1-cp314-cp314-win_amd64.whl", hash = "sha256:5e01429a929600e7dab7b166062d9bb54a5eed752384c7384c968c2afab8f50f", size = 45074, upload-time = "2026-01-26T02:45:37.546Z" },
+    { url = "https://files.pythonhosted.org/packages/97/ab/22803b03285fa3a525f48217963da3a65ae40f6a1b6f6cf2768879e208f9/multidict-6.7.1-cp314-cp314-win_arm64.whl", hash = "sha256:4885cb0e817aef5d00a2e8451d4665c1808378dc27c2705f1bf4ef8505c0d2e5", size = 42471, upload-time = "2026-01-26T02:45:38.889Z" },
+    { url = "https://files.pythonhosted.org/packages/e0/6d/f9293baa6146ba9507e360ea0292b6422b016907c393e2f63fc40ab7b7b5/multidict-6.7.1-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:0458c978acd8e6ea53c81eefaddbbee9c6c5e591f41b3f5e8e194780fe026581", size = 82401, upload-time = "2026-01-26T02:45:40.254Z" },
+    { url = "https://files.pythonhosted.org/packages/7a/68/53b5494738d83558d87c3c71a486504d8373421c3e0dbb6d0db48ad42ee0/multidict-6.7.1-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:c0abd12629b0af3cf590982c0b413b1e7395cd4ec026f30986818ab95bfaa94a", size = 48143, upload-time = "2026-01-26T02:45:41.635Z" },
+    { url = "https://files.pythonhosted.org/packages/37/e8/5284c53310dcdc99ce5d66563f6e5773531a9b9fe9ec7a615e9bc306b05f/multidict-6.7.1-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:14525a5f61d7d0c94b368a42cff4c9a4e7ba2d52e2672a7b23d84dc86fb02b0c", size = 46507, upload-time = "2026-01-26T02:45:42.99Z" },
+    { url = "https://files.pythonhosted.org/packages/e4/fc/6800d0e5b3875568b4083ecf5f310dcf91d86d52573160834fb4bfcf5e4f/multidict-6.7.1-cp314-cp314t-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:17307b22c217b4cf05033dabefe68255a534d637c6c9b0cc8382718f87be4262", size = 239358, upload-time = "2026-01-26T02:45:44.376Z" },
+    { url = "https://files.pythonhosted.org/packages/41/75/4ad0973179361cdf3a113905e6e088173198349131be2b390f9fa4da5fc6/multidict-6.7.1-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:7a7e590ff876a3eaf1c02a4dfe0724b6e69a9e9de6d8f556816f29c496046e59", size = 246884, upload-time = "2026-01-26T02:45:47.167Z" },
+    { url = "https://files.pythonhosted.org/packages/c3/9c/095bb28b5da139bd41fb9a5d5caff412584f377914bd8787c2aa98717130/multidict-6.7.1-cp314-cp314t-manylinux2014_armv7l.manylinux_2_17_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:5fa6a95dfee63893d80a34758cd0e0c118a30b8dcb46372bf75106c591b77889", size = 225878, upload-time = "2026-01-26T02:45:48.698Z" },
+    { url = "https://files.pythonhosted.org/packages/07/d0/c0a72000243756e8f5a277b6b514fa005f2c73d481b7d9e47cd4568aa2e4/multidict-6.7.1-cp314-cp314t-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:a0543217a6a017692aa6ae5cc39adb75e587af0f3a82288b1492eb73dd6cc2a4", size = 253542, upload-time = "2026-01-26T02:45:50.164Z" },
+    { url = "https://files.pythonhosted.org/packages/c0/6b/f69da15289e384ecf2a68837ec8b5ad8c33e973aa18b266f50fe55f24b8c/multidict-6.7.1-cp314-cp314t-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:f99fe611c312b3c1c0ace793f92464d8cd263cc3b26b5721950d977b006b6c4d", size = 252403, upload-time = "2026-01-26T02:45:51.779Z" },
+    { url = "https://files.pythonhosted.org/packages/a2/76/b9669547afa5a1a25cd93eaca91c0da1c095b06b6d2d8ec25b713588d3a1/multidict-6.7.1-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:9004d8386d133b7e6135679424c91b0b854d2d164af6ea3f289f8f2761064609", size = 244889, upload-time = "2026-01-26T02:45:53.27Z" },
+    { url = "https://files.pythonhosted.org/packages/7e/a9/a50d2669e506dad33cfc45b5d574a205587b7b8a5f426f2fbb2e90882588/multidict-6.7.1-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:e628ef0e6859ffd8273c69412a2465c4be4a9517d07261b33334b5ec6f3c7489", size = 241982, upload-time = "2026-01-26T02:45:54.919Z" },
+    { url = "https://files.pythonhosted.org/packages/c5/bb/1609558ad8b456b4827d3c5a5b775c93b87878fd3117ed3db3423dfbce1b/multidict-6.7.1-cp314-cp314t-musllinux_1_2_armv7l.whl", hash = "sha256:841189848ba629c3552035a6a7f5bf3b02eb304e9fea7492ca220a8eda6b0e5c", size = 232415, upload-time = "2026-01-26T02:45:56.981Z" },
+    { url = "https://files.pythonhosted.org/packages/d8/59/6f61039d2aa9261871e03ab9dc058a550d240f25859b05b67fd70f80d4b3/multidict-6.7.1-cp314-cp314t-musllinux_1_2_i686.whl", hash = "sha256:ce1bbd7d780bb5a0da032e095c951f7014d6b0a205f8318308140f1a6aba159e", size = 240337, upload-time = "2026-01-26T02:45:58.698Z" },
+    { url = "https://files.pythonhosted.org/packages/a1/29/fdc6a43c203890dc2ae9249971ecd0c41deaedfe00d25cb6564b2edd99eb/multidict-6.7.1-cp314-cp314t-musllinux_1_2_ppc64le.whl", hash = "sha256:b26684587228afed0d50cf804cc71062cc9c1cdf55051c4c6345d372947b268c", size = 248788, upload-time = "2026-01-26T02:46:00.862Z" },
+    { url = "https://files.pythonhosted.org/packages/a9/14/a153a06101323e4cf086ecee3faadba52ff71633d471f9685c42e3736163/multidict-6.7.1-cp314-cp314t-musllinux_1_2_s390x.whl", hash = "sha256:9f9af11306994335398293f9958071019e3ab95e9a707dc1383a35613f6abcb9", size = 242842, upload-time = "2026-01-26T02:46:02.824Z" },
+    { url = "https://files.pythonhosted.org/packages/41/5f/604ae839e64a4a6efc80db94465348d3b328ee955e37acb24badbcd24d83/multidict-6.7.1-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:b4938326284c4f1224178a560987b6cf8b4d38458b113d9b8c1db1a836e640a2", size = 240237, upload-time = "2026-01-26T02:46:05.898Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/60/c3a5187bf66f6fb546ff4ab8fb5a077cbdd832d7b1908d4365c7f74a1917/multidict-6.7.1-cp314-cp314t-win32.whl", hash = "sha256:98655c737850c064a65e006a3df7c997cd3b220be4ec8fe26215760b9697d4d7", size = 48008, upload-time = "2026-01-26T02:46:07.468Z" },
+    { url = "https://files.pythonhosted.org/packages/0c/f7/addf1087b860ac60e6f382240f64fb99f8bfb532bb06f7c542b83c29ca61/multidict-6.7.1-cp314-cp314t-win_amd64.whl", hash = "sha256:497bde6223c212ba11d462853cfa4f0ae6ef97465033e7dc9940cdb3ab5b48e5", size = 53542, upload-time = "2026-01-26T02:46:08.809Z" },
+    { url = "https://files.pythonhosted.org/packages/4c/81/4629d0aa32302ef7b2ec65c75a728cc5ff4fa410c50096174c1632e70b3e/multidict-6.7.1-cp314-cp314t-win_arm64.whl", hash = "sha256:2bbd113e0d4af5db41d5ebfe9ccaff89de2120578164f86a5d17d5a576d1e5b2", size = 44719, upload-time = "2026-01-26T02:46:11.146Z" },
+    { url = "https://files.pythonhosted.org/packages/81/08/7036c080d7117f28a4af526d794aab6a84463126db031b007717c1a6676e/multidict-6.7.1-py3-none-any.whl", hash = "sha256:55d97cc6dae627efa6a6e548885712d4864b81110ac76fa4e534c03819fa4a56", size = 12319, upload-time = "2026-01-26T02:46:44.004Z" },
+]
+
+[[package]]
+name = "packageurl-python"
+version = "0.17.6"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f5/d6/3b5a4e3cfaef7a53869a26ceb034d1ff5e5c27c814ce77260a96d50ab7bb/packageurl_python-0.17.6.tar.gz", hash = "sha256:1252ce3a102372ca6f86eb968e16f9014c4ba511c5c37d95a7f023e2ca6e5c25", size = 50618, upload-time = "2025-11-24T15:20:17.998Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b1/2f/c7277b7615a93f51b5fbc1eacfc1b75e8103370e786fd8ce2abf6e5c04ab/packageurl_python-0.17.6-py3-none-any.whl", hash = "sha256:31a85c2717bc41dd818f3c62908685ff9eebcb68588213745b14a6ee9e7df7c9", size = 36776, upload-time = "2025-11-24T15:20:16.962Z" },
+]
+
+[[package]]
+name = "packaging"
+version = "26.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/65/ee/299d360cdc32edc7d2cf530f3accf79c4fca01e96ffc950d8a52213bd8e4/packaging-26.0.tar.gz", hash = "sha256:00243ae351a257117b6a241061796684b084ed1c516a08c48a3f7e147a9d80b4", size = 143416, upload-time = "2026-01-21T20:50:39.064Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b7/b9/c538f279a4e237a006a2c98387d081e9eb060d203d8ed34467cc0f0b9b53/packaging-26.0-py3-none-any.whl", hash = "sha256:b36f1fef9334a5588b4166f8bcd26a14e521f2b55e6b9de3aaa80d3ff7a37529", size = 74366, upload-time = "2026-01-21T20:50:37.788Z" },
+]
+
+[[package]]
+name = "pip"
+version = "26.0.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/48/83/0d7d4e9efe3344b8e2fe25d93be44f64b65364d3c8d7bc6dc90198d5422e/pip-26.0.1.tar.gz", hash = "sha256:c4037d8a277c89b320abe636d59f91e6d0922d08a05b60e85e53b296613346d8", size = 1812747, upload-time = "2026-02-05T02:20:18.702Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/de/f0/c81e05b613866b76d2d1066490adf1a3dbc4ee9d9c839961c3fc8a6997af/pip-26.0.1-py3-none-any.whl", hash = "sha256:bdb1b08f4274833d62c1aa29e20907365a2ceb950410df15fc9521bad440122b", size = 1787723, upload-time = "2026-02-05T02:20:16.416Z" },
+]
+
+[[package]]
+name = "pip-api"
+version = "0.0.34"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pip" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b9/f1/ee85f8c7e82bccf90a3c7aad22863cc6e20057860a1361083cd2adacb92e/pip_api-0.0.34.tar.gz", hash = "sha256:9b75e958f14c5a2614bae415f2adf7eeb54d50a2cfbe7e24fd4826471bac3625", size = 123017, upload-time = "2024-07-09T20:32:30.641Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/91/f7/ebf5003e1065fd00b4cbef53bf0a65c3d3e1b599b676d5383ccb7a8b88ba/pip_api-0.0.34-py3-none-any.whl", hash = "sha256:8b2d7d7c37f2447373aa2cf8b1f60a2f2b27a84e1e9e0294a3f6ef10eb3ba6bb", size = 120369, upload-time = "2024-07-09T20:32:29.099Z" },
+]
+
+[[package]]
+name = "pip-audit"
+version = "2.10.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "cachecontrol", extra = ["filecache"] },
+    { name = "cyclonedx-python-lib" },
+    { name = "packaging" },
+    { name = "pip-api" },
+    { name = "pip-requirements-parser" },
+    { name = "platformdirs" },
+    { name = "requests" },
+    { name = "rich" },
+    { name = "tomli" },
+    { name = "tomli-w" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/bd/89/0e999b413facab81c33d118f3ac3739fd02c0622ccf7c4e82e37cebd8447/pip_audit-2.10.0.tar.gz", hash = "sha256:427ea5bf61d1d06b98b1ae29b7feacc00288a2eced52c9c58ceed5253ef6c2a4", size = 53776, upload-time = "2025-12-01T23:42:40.612Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/be/f3/4888f895c02afa085630a3a3329d1b18b998874642ad4c530e9a4d7851fe/pip_audit-2.10.0-py3-none-any.whl", hash = "sha256:16e02093872fac97580303f0848fa3ad64f7ecf600736ea7835a2b24de49613f", size = 61518, upload-time = "2025-12-01T23:42:39.193Z" },
+]
+
+[[package]]
+name = "pip-requirements-parser"
+version = "32.0.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "packaging" },
+    { name = "pyparsing" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/5e/2a/63b574101850e7f7b306ddbdb02cb294380d37948140eecd468fae392b54/pip-requirements-parser-32.0.1.tar.gz", hash = "sha256:b4fa3a7a0be38243123cf9d1f3518da10c51bdb165a2b2985566247f9155a7d3", size = 209359, upload-time = "2022-12-21T15:25:22.732Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/54/d0/d04f1d1e064ac901439699ee097f58688caadea42498ec9c4b4ad2ef84ab/pip_requirements_parser-32.0.1-py3-none-any.whl", hash = "sha256:4659bc2a667783e7a15d190f6fccf8b2486685b6dba4c19c3876314769c57526", size = 35648, upload-time = "2022-12-21T15:25:21.046Z" },
+]
+
+[[package]]
+name = "platformdirs"
+version = "4.9.6"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/9f/4a/0883b8e3802965322523f0b200ecf33d31f10991d0401162f4b23c698b42/platformdirs-4.9.6.tar.gz", hash = "sha256:3bfa75b0ad0db84096ae777218481852c0ebc6c727b3168c1b9e0118e458cf0a", size = 29400, upload-time = "2026-04-09T00:04:10.812Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/75/a6/a0a304dc33b49145b21f4808d763822111e67d1c3a32b524a1baf947b6e1/platformdirs-4.9.6-py3-none-any.whl", hash = "sha256:e61adb1d5e5cb3441b4b7710bea7e4c12250ca49439228cc1021c00dcfac0917", size = 21348, upload-time = "2026-04-09T00:04:09.463Z" },
+]
+
+[[package]]
+name = "pluggy"
+version = "1.6.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f9/e2/3e91f31a7d2b083fe6ef3fa267035b518369d9511ffab804f839851d2779/pluggy-1.6.0.tar.gz", hash = "sha256:7dcc130b76258d33b90f61b658791dede3486c3e6bfb003ee5c9bfb396dd22f3", size = 69412, upload-time = "2025-05-15T12:30:07.975Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/54/20/4d324d65cc6d9205fabedc306948156824eb9f0ee1633355a8f7ec5c66bf/pluggy-1.6.0-py3-none-any.whl", hash = "sha256:e920276dd6813095e9377c0bc5566d94c932c33b27a3e3945d8389c374dd4746", size = 20538, upload-time = "2025-05-15T12:30:06.134Z" },
+]
+
+[[package]]
+name = "propcache"
+version = "0.4.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/9e/da/e9fc233cf63743258bff22b3dfa7ea5baef7b5bc324af47a0ad89b8ffc6f/propcache-0.4.1.tar.gz", hash = "sha256:f48107a8c637e80362555f37ecf49abe20370e557cc4ab374f04ec4423c97c3d", size = 46442, upload-time = "2025-10-08T19:49:02.291Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/8e/5c/bca52d654a896f831b8256683457ceddd490ec18d9ec50e97dfd8fc726a8/propcache-0.4.1-cp314-cp314-macosx_10_13_universal2.whl", hash = "sha256:3f7124c9d820ba5548d431afb4632301acf965db49e666aa21c305cbe8c6de12", size = 78152, upload-time = "2025-10-08T19:47:51.051Z" },
+    { url = "https://files.pythonhosted.org/packages/65/9b/03b04e7d82a5f54fb16113d839f5ea1ede58a61e90edf515f6577c66fa8f/propcache-0.4.1-cp314-cp314-macosx_10_13_x86_64.whl", hash = "sha256:c0d4b719b7da33599dfe3b22d3db1ef789210a0597bc650b7cee9c77c2be8c5c", size = 44869, upload-time = "2025-10-08T19:47:52.594Z" },
+    { url = "https://files.pythonhosted.org/packages/b2/fa/89a8ef0468d5833a23fff277b143d0573897cf75bd56670a6d28126c7d68/propcache-0.4.1-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:9f302f4783709a78240ebc311b793f123328716a60911d667e0c036bc5dcbded", size = 46596, upload-time = "2025-10-08T19:47:54.073Z" },
+    { url = "https://files.pythonhosted.org/packages/86/bd/47816020d337f4a746edc42fe8d53669965138f39ee117414c7d7a340cfe/propcache-0.4.1-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:c80ee5802e3fb9ea37938e7eecc307fb984837091d5fd262bb37238b1ae97641", size = 206981, upload-time = "2025-10-08T19:47:55.715Z" },
+    { url = "https://files.pythonhosted.org/packages/df/f6/c5fa1357cc9748510ee55f37173eb31bfde6d94e98ccd9e6f033f2fc06e1/propcache-0.4.1-cp314-cp314-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:ed5a841e8bb29a55fb8159ed526b26adc5bdd7e8bd7bf793ce647cb08656cdf4", size = 211490, upload-time = "2025-10-08T19:47:57.499Z" },
+    { url = "https://files.pythonhosted.org/packages/80/1e/e5889652a7c4a3846683401a48f0f2e5083ce0ec1a8a5221d8058fbd1adf/propcache-0.4.1-cp314-cp314-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:55c72fd6ea2da4c318e74ffdf93c4fe4e926051133657459131a95c846d16d44", size = 215371, upload-time = "2025-10-08T19:47:59.317Z" },
+    { url = "https://files.pythonhosted.org/packages/b2/f2/889ad4b2408f72fe1a4f6a19491177b30ea7bf1a0fd5f17050ca08cfc882/propcache-0.4.1-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:8326e144341460402713f91df60ade3c999d601e7eb5ff8f6f7862d54de0610d", size = 201424, upload-time = "2025-10-08T19:48:00.67Z" },
+    { url = "https://files.pythonhosted.org/packages/27/73/033d63069b57b0812c8bd19f311faebeceb6ba31b8f32b73432d12a0b826/propcache-0.4.1-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:060b16ae65bc098da7f6d25bf359f1f31f688384858204fe5d652979e0015e5b", size = 197566, upload-time = "2025-10-08T19:48:02.604Z" },
+    { url = "https://files.pythonhosted.org/packages/dc/89/ce24f3dc182630b4e07aa6d15f0ff4b14ed4b9955fae95a0b54c58d66c05/propcache-0.4.1-cp314-cp314-musllinux_1_2_armv7l.whl", hash = "sha256:89eb3fa9524f7bec9de6e83cf3faed9d79bffa560672c118a96a171a6f55831e", size = 193130, upload-time = "2025-10-08T19:48:04.499Z" },
+    { url = "https://files.pythonhosted.org/packages/a9/24/ef0d5fd1a811fb5c609278d0209c9f10c35f20581fcc16f818da959fc5b4/propcache-0.4.1-cp314-cp314-musllinux_1_2_ppc64le.whl", hash = "sha256:dee69d7015dc235f526fe80a9c90d65eb0039103fe565776250881731f06349f", size = 202625, upload-time = "2025-10-08T19:48:06.213Z" },
+    { url = "https://files.pythonhosted.org/packages/f5/02/98ec20ff5546f68d673df2f7a69e8c0d076b5abd05ca882dc7ee3a83653d/propcache-0.4.1-cp314-cp314-musllinux_1_2_s390x.whl", hash = "sha256:5558992a00dfd54ccbc64a32726a3357ec93825a418a401f5cc67df0ac5d9e49", size = 204209, upload-time = "2025-10-08T19:48:08.432Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/87/492694f76759b15f0467a2a93ab68d32859672b646aa8a04ce4864e7932d/propcache-0.4.1-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:c9b822a577f560fbd9554812526831712c1436d2c046cedee4c3796d3543b144", size = 197797, upload-time = "2025-10-08T19:48:09.968Z" },
+    { url = "https://files.pythonhosted.org/packages/ee/36/66367de3575db1d2d3f3d177432bd14ee577a39d3f5d1b3d5df8afe3b6e2/propcache-0.4.1-cp314-cp314-win32.whl", hash = "sha256:ab4c29b49d560fe48b696cdcb127dd36e0bc2472548f3bf56cc5cb3da2b2984f", size = 38140, upload-time = "2025-10-08T19:48:11.232Z" },
+    { url = "https://files.pythonhosted.org/packages/0c/2a/a758b47de253636e1b8aef181c0b4f4f204bf0dd964914fb2af90a95b49b/propcache-0.4.1-cp314-cp314-win_amd64.whl", hash = "sha256:5a103c3eb905fcea0ab98be99c3a9a5ab2de60228aa5aceedc614c0281cf6153", size = 41257, upload-time = "2025-10-08T19:48:12.707Z" },
+    { url = "https://files.pythonhosted.org/packages/34/5e/63bd5896c3fec12edcbd6f12508d4890d23c265df28c74b175e1ef9f4f3b/propcache-0.4.1-cp314-cp314-win_arm64.whl", hash = "sha256:74c1fb26515153e482e00177a1ad654721bf9207da8a494a0c05e797ad27b992", size = 38097, upload-time = "2025-10-08T19:48:13.923Z" },
+    { url = "https://files.pythonhosted.org/packages/99/85/9ff785d787ccf9bbb3f3106f79884a130951436f58392000231b4c737c80/propcache-0.4.1-cp314-cp314t-macosx_10_13_universal2.whl", hash = "sha256:824e908bce90fb2743bd6b59db36eb4f45cd350a39637c9f73b1c1ea66f5b75f", size = 81455, upload-time = "2025-10-08T19:48:15.16Z" },
+    { url = "https://files.pythonhosted.org/packages/90/85/2431c10c8e7ddb1445c1f7c4b54d886e8ad20e3c6307e7218f05922cad67/propcache-0.4.1-cp314-cp314t-macosx_10_13_x86_64.whl", hash = "sha256:c2b5e7db5328427c57c8e8831abda175421b709672f6cfc3d630c3b7e2146393", size = 46372, upload-time = "2025-10-08T19:48:16.424Z" },
+    { url = "https://files.pythonhosted.org/packages/01/20/b0972d902472da9bcb683fa595099911f4d2e86e5683bcc45de60dd05dc3/propcache-0.4.1-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:6f6ff873ed40292cd4969ef5310179afd5db59fdf055897e282485043fc80ad0", size = 48411, upload-time = "2025-10-08T19:48:17.577Z" },
+    { url = "https://files.pythonhosted.org/packages/e2/e3/7dc89f4f21e8f99bad3d5ddb3a3389afcf9da4ac69e3deb2dcdc96e74169/propcache-0.4.1-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:49a2dc67c154db2c1463013594c458881a069fcf98940e61a0569016a583020a", size = 275712, upload-time = "2025-10-08T19:48:18.901Z" },
+    { url = "https://files.pythonhosted.org/packages/20/67/89800c8352489b21a8047c773067644e3897f02ecbbd610f4d46b7f08612/propcache-0.4.1-cp314-cp314t-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:005f08e6a0529984491e37d8dbc3dd86f84bd78a8ceb5fa9a021f4c48d4984be", size = 273557, upload-time = "2025-10-08T19:48:20.762Z" },
+    { url = "https://files.pythonhosted.org/packages/e2/a1/b52b055c766a54ce6d9c16d9aca0cad8059acd9637cdf8aa0222f4a026ef/propcache-0.4.1-cp314-cp314t-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:5c3310452e0d31390da9035c348633b43d7e7feb2e37be252be6da45abd1abcc", size = 280015, upload-time = "2025-10-08T19:48:22.592Z" },
+    { url = "https://files.pythonhosted.org/packages/48/c8/33cee30bd890672c63743049f3c9e4be087e6780906bfc3ec58528be59c1/propcache-0.4.1-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:4c3c70630930447f9ef1caac7728c8ad1c56bc5015338b20fed0d08ea2480b3a", size = 262880, upload-time = "2025-10-08T19:48:23.947Z" },
+    { url = "https://files.pythonhosted.org/packages/0c/b1/8f08a143b204b418285c88b83d00edbd61afbc2c6415ffafc8905da7038b/propcache-0.4.1-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:8e57061305815dfc910a3634dcf584f08168a8836e6999983569f51a8544cd89", size = 260938, upload-time = "2025-10-08T19:48:25.656Z" },
+    { url = "https://files.pythonhosted.org/packages/cf/12/96e4664c82ca2f31e1c8dff86afb867348979eb78d3cb8546a680287a1e9/propcache-0.4.1-cp314-cp314t-musllinux_1_2_armv7l.whl", hash = "sha256:521a463429ef54143092c11a77e04056dd00636f72e8c45b70aaa3140d639726", size = 247641, upload-time = "2025-10-08T19:48:27.207Z" },
+    { url = "https://files.pythonhosted.org/packages/18/ed/e7a9cfca28133386ba52278136d42209d3125db08d0a6395f0cba0c0285c/propcache-0.4.1-cp314-cp314t-musllinux_1_2_ppc64le.whl", hash = "sha256:120c964da3fdc75e3731aa392527136d4ad35868cc556fd09bb6d09172d9a367", size = 262510, upload-time = "2025-10-08T19:48:28.65Z" },
+    { url = "https://files.pythonhosted.org/packages/f5/76/16d8bf65e8845dd62b4e2b57444ab81f07f40caa5652b8969b87ddcf2ef6/propcache-0.4.1-cp314-cp314t-musllinux_1_2_s390x.whl", hash = "sha256:d8f353eb14ee3441ee844ade4277d560cdd68288838673273b978e3d6d2c8f36", size = 263161, upload-time = "2025-10-08T19:48:30.133Z" },
+    { url = "https://files.pythonhosted.org/packages/e7/70/c99e9edb5d91d5ad8a49fa3c1e8285ba64f1476782fed10ab251ff413ba1/propcache-0.4.1-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:ab2943be7c652f09638800905ee1bab2c544e537edb57d527997a24c13dc1455", size = 257393, upload-time = "2025-10-08T19:48:31.567Z" },
+    { url = "https://files.pythonhosted.org/packages/08/02/87b25304249a35c0915d236575bc3574a323f60b47939a2262b77632a3ee/propcache-0.4.1-cp314-cp314t-win32.whl", hash = "sha256:05674a162469f31358c30bcaa8883cb7829fa3110bf9c0991fe27d7896c42d85", size = 42546, upload-time = "2025-10-08T19:48:32.872Z" },
+    { url = "https://files.pythonhosted.org/packages/cb/ef/3c6ecf8b317aa982f309835e8f96987466123c6e596646d4e6a1dfcd080f/propcache-0.4.1-cp314-cp314t-win_amd64.whl", hash = "sha256:990f6b3e2a27d683cb7602ed6c86f15ee6b43b1194736f9baaeb93d0016633b1", size = 46259, upload-time = "2025-10-08T19:48:34.226Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/2d/346e946d4951f37eca1e4f55be0f0174c52cd70720f84029b02f296f4a38/propcache-0.4.1-cp314-cp314t-win_arm64.whl", hash = "sha256:ecef2343af4cc68e05131e45024ba34f6095821988a9d0a02aa7c73fcc448aa9", size = 40428, upload-time = "2025-10-08T19:48:35.441Z" },
+    { url = "https://files.pythonhosted.org/packages/5b/5a/bc7b4a4ef808fa59a816c17b20c4bef6884daebbdf627ff2a161da67da19/propcache-0.4.1-py3-none-any.whl", hash = "sha256:af2a6052aeb6cf17d3e46ee169099044fd8224cbaf75c76a2ef596e8163e2237", size = 13305, upload-time = "2025-10-08T19:49:00.792Z" },
+]
+
+[[package]]
+name = "py-serializable"
+version = "2.1.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "defusedxml" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/73/21/d250cfca8ff30c2e5a7447bc13861541126ce9bd4426cd5d0c9f08b5547d/py_serializable-2.1.0.tar.gz", hash = "sha256:9d5db56154a867a9b897c0163b33a793c804c80cee984116d02d49e4578fc103", size = 52368, upload-time = "2025-07-21T09:56:48.07Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9b/bf/7595e817906a29453ba4d99394e781b6fabe55d21f3c15d240f85dd06bb1/py_serializable-2.1.0-py3-none-any.whl", hash = "sha256:b56d5d686b5a03ba4f4db5e769dc32336e142fc3bd4d68a8c25579ebb0a67304", size = 23045, upload-time = "2025-07-21T09:56:46.848Z" },
+]
+
+[[package]]
+name = "pydantic"
+version = "2.12.5"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "annotated-types" },
+    { name = "pydantic-core" },
+    { name = "typing-extensions" },
+    { name = "typing-inspection" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/69/44/36f1a6e523abc58ae5f928898e4aca2e0ea509b5aa6f6f392a5d882be928/pydantic-2.12.5.tar.gz", hash = "sha256:4d351024c75c0f085a9febbb665ce8c0c6ec5d30e903bdb6394b7ede26aebb49", size = 821591, upload-time = "2025-11-26T15:11:46.471Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5a/87/b70ad306ebb6f9b585f114d0ac2137d792b48be34d732d60e597c2f8465a/pydantic-2.12.5-py3-none-any.whl", hash = "sha256:e561593fccf61e8a20fc46dfc2dfe075b8be7d0188df33f221ad1f0139180f9d", size = 463580, upload-time = "2025-11-26T15:11:44.605Z" },
+]
+
+[[package]]
+name = "pydantic-core"
+version = "2.41.5"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/71/70/23b021c950c2addd24ec408e9ab05d59b035b39d97cdc1130e1bce647bb6/pydantic_core-2.41.5.tar.gz", hash = "sha256:08daa51ea16ad373ffd5e7606252cc32f07bc72b28284b6bc9c6df804816476e", size = 460952, upload-time = "2025-11-04T13:43:49.098Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ea/28/46b7c5c9635ae96ea0fbb779e271a38129df2550f763937659ee6c5dbc65/pydantic_core-2.41.5-cp314-cp314-macosx_10_12_x86_64.whl", hash = "sha256:3f37a19d7ebcdd20b96485056ba9e8b304e27d9904d233d7b1015db320e51f0a", size = 2119622, upload-time = "2025-11-04T13:40:56.68Z" },
+    { url = "https://files.pythonhosted.org/packages/74/1a/145646e5687e8d9a1e8d09acb278c8535ebe9e972e1f162ed338a622f193/pydantic_core-2.41.5-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:1d1d9764366c73f996edd17abb6d9d7649a7eb690006ab6adbda117717099b14", size = 1891725, upload-time = "2025-11-04T13:40:58.807Z" },
+    { url = "https://files.pythonhosted.org/packages/23/04/e89c29e267b8060b40dca97bfc64a19b2a3cf99018167ea1677d96368273/pydantic_core-2.41.5-cp314-cp314-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:25e1c2af0fce638d5f1988b686f3b3ea8cd7de5f244ca147c777769e798a9cd1", size = 1915040, upload-time = "2025-11-04T13:41:00.853Z" },
+    { url = "https://files.pythonhosted.org/packages/84/a3/15a82ac7bd97992a82257f777b3583d3e84bdb06ba6858f745daa2ec8a85/pydantic_core-2.41.5-cp314-cp314-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:506d766a8727beef16b7adaeb8ee6217c64fc813646b424d0804d67c16eddb66", size = 2063691, upload-time = "2025-11-04T13:41:03.504Z" },
+    { url = "https://files.pythonhosted.org/packages/74/9b/0046701313c6ef08c0c1cf0e028c67c770a4e1275ca73131563c5f2a310a/pydantic_core-2.41.5-cp314-cp314-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:4819fa52133c9aa3c387b3328f25c1facc356491e6135b459f1de698ff64d869", size = 2213897, upload-time = "2025-11-04T13:41:05.804Z" },
+    { url = "https://files.pythonhosted.org/packages/8a/cd/6bac76ecd1b27e75a95ca3a9a559c643b3afcd2dd62086d4b7a32a18b169/pydantic_core-2.41.5-cp314-cp314-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:2b761d210c9ea91feda40d25b4efe82a1707da2ef62901466a42492c028553a2", size = 2333302, upload-time = "2025-11-04T13:41:07.809Z" },
+    { url = "https://files.pythonhosted.org/packages/4c/d2/ef2074dc020dd6e109611a8be4449b98cd25e1b9b8a303c2f0fca2f2bcf7/pydantic_core-2.41.5-cp314-cp314-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:22f0fb8c1c583a3b6f24df2470833b40207e907b90c928cc8d3594b76f874375", size = 2064877, upload-time = "2025-11-04T13:41:09.827Z" },
+    { url = "https://files.pythonhosted.org/packages/18/66/e9db17a9a763d72f03de903883c057b2592c09509ccfe468187f2a2eef29/pydantic_core-2.41.5-cp314-cp314-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:2782c870e99878c634505236d81e5443092fba820f0373997ff75f90f68cd553", size = 2180680, upload-time = "2025-11-04T13:41:12.379Z" },
+    { url = "https://files.pythonhosted.org/packages/d3/9e/3ce66cebb929f3ced22be85d4c2399b8e85b622db77dad36b73c5387f8f8/pydantic_core-2.41.5-cp314-cp314-musllinux_1_1_aarch64.whl", hash = "sha256:0177272f88ab8312479336e1d777f6b124537d47f2123f89cb37e0accea97f90", size = 2138960, upload-time = "2025-11-04T13:41:14.627Z" },
+    { url = "https://files.pythonhosted.org/packages/a6/62/205a998f4327d2079326b01abee48e502ea739d174f0a89295c481a2272e/pydantic_core-2.41.5-cp314-cp314-musllinux_1_1_armv7l.whl", hash = "sha256:63510af5e38f8955b8ee5687740d6ebf7c2a0886d15a6d65c32814613681bc07", size = 2339102, upload-time = "2025-11-04T13:41:16.868Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/0d/f05e79471e889d74d3d88f5bd20d0ed189ad94c2423d81ff8d0000aab4ff/pydantic_core-2.41.5-cp314-cp314-musllinux_1_1_x86_64.whl", hash = "sha256:e56ba91f47764cc14f1daacd723e3e82d1a89d783f0f5afe9c364b8bb491ccdb", size = 2326039, upload-time = "2025-11-04T13:41:18.934Z" },
+    { url = "https://files.pythonhosted.org/packages/ec/e1/e08a6208bb100da7e0c4b288eed624a703f4d129bde2da475721a80cab32/pydantic_core-2.41.5-cp314-cp314-win32.whl", hash = "sha256:aec5cf2fd867b4ff45b9959f8b20ea3993fc93e63c7363fe6851424c8a7e7c23", size = 1995126, upload-time = "2025-11-04T13:41:21.418Z" },
+    { url = "https://files.pythonhosted.org/packages/48/5d/56ba7b24e9557f99c9237e29f5c09913c81eeb2f3217e40e922353668092/pydantic_core-2.41.5-cp314-cp314-win_amd64.whl", hash = "sha256:8e7c86f27c585ef37c35e56a96363ab8de4e549a95512445b85c96d3e2f7c1bf", size = 2015489, upload-time = "2025-11-04T13:41:24.076Z" },
+    { url = "https://files.pythonhosted.org/packages/4e/bb/f7a190991ec9e3e0ba22e4993d8755bbc4a32925c0b5b42775c03e8148f9/pydantic_core-2.41.5-cp314-cp314-win_arm64.whl", hash = "sha256:e672ba74fbc2dc8eea59fb6d4aed6845e6905fc2a8afe93175d94a83ba2a01a0", size = 1977288, upload-time = "2025-11-04T13:41:26.33Z" },
+    { url = "https://files.pythonhosted.org/packages/92/ed/77542d0c51538e32e15afe7899d79efce4b81eee631d99850edc2f5e9349/pydantic_core-2.41.5-cp314-cp314t-macosx_10_12_x86_64.whl", hash = "sha256:8566def80554c3faa0e65ac30ab0932b9e3a5cd7f8323764303d468e5c37595a", size = 2120255, upload-time = "2025-11-04T13:41:28.569Z" },
+    { url = "https://files.pythonhosted.org/packages/bb/3d/6913dde84d5be21e284439676168b28d8bbba5600d838b9dca99de0fad71/pydantic_core-2.41.5-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:b80aa5095cd3109962a298ce14110ae16b8c1aece8b72f9dafe81cf597ad80b3", size = 1863760, upload-time = "2025-11-04T13:41:31.055Z" },
+    { url = "https://files.pythonhosted.org/packages/5a/f0/e5e6b99d4191da102f2b0eb9687aaa7f5bea5d9964071a84effc3e40f997/pydantic_core-2.41.5-cp314-cp314t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:3006c3dd9ba34b0c094c544c6006cc79e87d8612999f1a5d43b769b89181f23c", size = 1878092, upload-time = "2025-11-04T13:41:33.21Z" },
+    { url = "https://files.pythonhosted.org/packages/71/48/36fb760642d568925953bcc8116455513d6e34c4beaa37544118c36aba6d/pydantic_core-2.41.5-cp314-cp314t-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:72f6c8b11857a856bcfa48c86f5368439f74453563f951e473514579d44aa612", size = 2053385, upload-time = "2025-11-04T13:41:35.508Z" },
+    { url = "https://files.pythonhosted.org/packages/20/25/92dc684dd8eb75a234bc1c764b4210cf2646479d54b47bf46061657292a8/pydantic_core-2.41.5-cp314-cp314t-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:5cb1b2f9742240e4bb26b652a5aeb840aa4b417c7748b6f8387927bc6e45e40d", size = 2218832, upload-time = "2025-11-04T13:41:37.732Z" },
+    { url = "https://files.pythonhosted.org/packages/e2/09/f53e0b05023d3e30357d82eb35835d0f6340ca344720a4599cd663dca599/pydantic_core-2.41.5-cp314-cp314t-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:bd3d54f38609ff308209bd43acea66061494157703364ae40c951f83ba99a1a9", size = 2327585, upload-time = "2025-11-04T13:41:40Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/4e/2ae1aa85d6af35a39b236b1b1641de73f5a6ac4d5a7509f77b814885760c/pydantic_core-2.41.5-cp314-cp314t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:2ff4321e56e879ee8d2a879501c8e469414d948f4aba74a2d4593184eb326660", size = 2041078, upload-time = "2025-11-04T13:41:42.323Z" },
+    { url = "https://files.pythonhosted.org/packages/cd/13/2e215f17f0ef326fc72afe94776edb77525142c693767fc347ed6288728d/pydantic_core-2.41.5-cp314-cp314t-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:d0d2568a8c11bf8225044aa94409e21da0cb09dcdafe9ecd10250b2baad531a9", size = 2173914, upload-time = "2025-11-04T13:41:45.221Z" },
+    { url = "https://files.pythonhosted.org/packages/02/7a/f999a6dcbcd0e5660bc348a3991c8915ce6599f4f2c6ac22f01d7a10816c/pydantic_core-2.41.5-cp314-cp314t-musllinux_1_1_aarch64.whl", hash = "sha256:a39455728aabd58ceabb03c90e12f71fd30fa69615760a075b9fec596456ccc3", size = 2129560, upload-time = "2025-11-04T13:41:47.474Z" },
+    { url = "https://files.pythonhosted.org/packages/3a/b1/6c990ac65e3b4c079a4fb9f5b05f5b013afa0f4ed6780a3dd236d2cbdc64/pydantic_core-2.41.5-cp314-cp314t-musllinux_1_1_armv7l.whl", hash = "sha256:239edca560d05757817c13dc17c50766136d21f7cd0fac50295499ae24f90fdf", size = 2329244, upload-time = "2025-11-04T13:41:49.992Z" },
+    { url = "https://files.pythonhosted.org/packages/d9/02/3c562f3a51afd4d88fff8dffb1771b30cfdfd79befd9883ee094f5b6c0d8/pydantic_core-2.41.5-cp314-cp314t-musllinux_1_1_x86_64.whl", hash = "sha256:2a5e06546e19f24c6a96a129142a75cee553cc018ffee48a460059b1185f4470", size = 2331955, upload-time = "2025-11-04T13:41:54.079Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/96/5fb7d8c3c17bc8c62fdb031c47d77a1af698f1d7a406b0f79aaa1338f9ad/pydantic_core-2.41.5-cp314-cp314t-win32.whl", hash = "sha256:b4ececa40ac28afa90871c2cc2b9ffd2ff0bf749380fbdf57d165fd23da353aa", size = 1988906, upload-time = "2025-11-04T13:41:56.606Z" },
+    { url = "https://files.pythonhosted.org/packages/22/ed/182129d83032702912c2e2d8bbe33c036f342cc735737064668585dac28f/pydantic_core-2.41.5-cp314-cp314t-win_amd64.whl", hash = "sha256:80aa89cad80b32a912a65332f64a4450ed00966111b6615ca6816153d3585a8c", size = 1981607, upload-time = "2025-11-04T13:41:58.889Z" },
+    { url = "https://files.pythonhosted.org/packages/9f/ed/068e41660b832bb0b1aa5b58011dea2a3fe0ba7861ff38c4d4904c1c1a99/pydantic_core-2.41.5-cp314-cp314t-win_arm64.whl", hash = "sha256:35b44f37a3199f771c3eaa53051bc8a70cd7b54f333531c59e29fd4db5d15008", size = 1974769, upload-time = "2025-11-04T13:42:01.186Z" },
+]
+
+[[package]]
+name = "pygments"
+version = "2.20.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/c3/b2/bc9c9196916376152d655522fdcebac55e66de6603a76a02bca1b6414f6c/pygments-2.20.0.tar.gz", hash = "sha256:6757cd03768053ff99f3039c1a36d6c0aa0b263438fcab17520b30a303a82b5f", size = 4955991, upload-time = "2026-03-29T13:29:33.898Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f4/7e/a72dd26f3b0f4f2bf1dd8923c85f7ceb43172af56d63c7383eb62b332364/pygments-2.20.0-py3-none-any.whl", hash = "sha256:81a9e26dd42fd28a23a2d169d86d7ac03b46e2f8b59ed4698fb4785f946d0176", size = 1231151, upload-time = "2026-03-29T13:29:30.038Z" },
+]
+
+[[package]]
+name = "pyparsing"
+version = "3.3.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f3/91/9c6ee907786a473bf81c5f53cf703ba0957b23ab84c264080fb5a450416f/pyparsing-3.3.2.tar.gz", hash = "sha256:c777f4d763f140633dcb6d8a3eda953bf7a214dc4eff598413c070bcdc117cbc", size = 6851574, upload-time = "2026-01-21T03:57:59.36Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/10/bd/c038d7cc38edc1aa5bf91ab8068b63d4308c66c4c8bb3cbba7dfbc049f9c/pyparsing-3.3.2-py3-none-any.whl", hash = "sha256:850ba148bd908d7e2411587e247a1e4f0327839c40e2e5e6d05a007ecc69911d", size = 122781, upload-time = "2026-01-21T03:57:55.912Z" },
+]
+
+[[package]]
+name = "pytest"
+version = "9.0.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "iniconfig" },
+    { name = "packaging" },
+    { name = "pluggy" },
+    { name = "pygments" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/d1/db/7ef3487e0fb0049ddb5ce41d3a49c235bf9ad299b6a25d5780a89f19230f/pytest-9.0.2.tar.gz", hash = "sha256:75186651a92bd89611d1d9fc20f0b4345fd827c41ccd5c299a868a05d70edf11", size = 1568901, upload-time = "2025-12-06T21:30:51.014Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/3b/ab/b3226f0bd7cdcf710fbede2b3548584366da3b19b5021e74f5bde2a8fa3f/pytest-9.0.2-py3-none-any.whl", hash = "sha256:711ffd45bf766d5264d487b917733b453d917afd2b0ad65223959f59089f875b", size = 374801, upload-time = "2025-12-06T21:30:49.154Z" },
+]
+
+[[package]]
+name = "pytest-asyncio"
+version = "1.3.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pytest" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/90/2c/8af215c0f776415f3590cac4f9086ccefd6fd463befeae41cd4d3f193e5a/pytest_asyncio-1.3.0.tar.gz", hash = "sha256:d7f52f36d231b80ee124cd216ffb19369aa168fc10095013c6b014a34d3ee9e5", size = 50087, upload-time = "2025-11-10T16:07:47.256Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e5/35/f8b19922b6a25bc0880171a2f1a003eaeb93657475193ab516fd87cac9da/pytest_asyncio-1.3.0-py3-none-any.whl", hash = "sha256:611e26147c7f77640e6d0a92a38ed17c3e9848063698d5c93d5aa7aa11cebff5", size = 15075, upload-time = "2025-11-10T16:07:45.537Z" },
+]
+
+[[package]]
+name = "pytest-mock"
+version = "3.15.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pytest" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/68/14/eb014d26be205d38ad5ad20d9a80f7d201472e08167f0bb4361e251084a9/pytest_mock-3.15.1.tar.gz", hash = "sha256:1849a238f6f396da19762269de72cb1814ab44416fa73a8686deac10b0d87a0f", size = 34036, upload-time = "2025-09-16T16:37:27.081Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5a/cc/06253936f4a7fa2e0f48dfe6d851d9c56df896a9ab09ac019d70b760619c/pytest_mock-3.15.1-py3-none-any.whl", hash = "sha256:0a25e2eb88fe5168d535041d09a4529a188176ae608a6d249ee65abc0949630d", size = 10095, upload-time = "2025-09-16T16:37:25.734Z" },
+]
+
+[[package]]
+name = "pytest-xdist"
+version = "3.8.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "execnet" },
+    { name = "pytest" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/78/b4/439b179d1ff526791eb921115fca8e44e596a13efeda518b9d845a619450/pytest_xdist-3.8.0.tar.gz", hash = "sha256:7e578125ec9bc6050861aa93f2d59f1d8d085595d6551c2c90b6f4fad8d3a9f1", size = 88069, upload-time = "2025-07-01T13:30:59.346Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ca/31/d4e37e9e550c2b92a9cbc2e4d0b7420a27224968580b5a447f420847c975/pytest_xdist-3.8.0-py3-none-any.whl", hash = "sha256:202ca578cfeb7370784a8c33d6d05bc6e13b4f25b5053c30a152269fd10f0b88", size = 46396, upload-time = "2025-07-01T13:30:56.632Z" },
+]
+
+[[package]]
+name = "python-dotenv"
+version = "1.2.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/82/ed/0301aeeac3e5353ef3d94b6ec08bbcabd04a72018415dcb29e588514bba8/python_dotenv-1.2.2.tar.gz", hash = "sha256:2c371a91fbd7ba082c2c1dc1f8bf89ca22564a087c2c287cd9b662adde799cf3", size = 50135, upload-time = "2026-03-01T16:00:26.196Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/0b/d7/1959b9648791274998a9c3526f6d0ec8fd2233e4d4acce81bbae76b44b2a/python_dotenv-1.2.2-py3-none-any.whl", hash = "sha256:1d8214789a24de455a8b8bd8ae6fe3c6b69a5e3d64aa8a8e5d68e694bbcb285a", size = 22101, upload-time = "2026-03-01T16:00:25.09Z" },
+]
+
+[[package]]
+name = "pyyaml"
+version = "6.0.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/05/8e/961c0007c59b8dd7729d542c61a4d537767a59645b82a0b521206e1e25c2/pyyaml-6.0.3.tar.gz", hash = "sha256:d76623373421df22fb4cf8817020cbb7ef15c725b9d5e45f17e189bfc384190f", size = 130960, upload-time = "2025-09-25T21:33:16.546Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9d/8c/f4bd7f6465179953d3ac9bc44ac1a8a3e6122cf8ada906b4f96c60172d43/pyyaml-6.0.3-cp314-cp314-macosx_10_13_x86_64.whl", hash = "sha256:8d1fab6bb153a416f9aeb4b8763bc0f22a5586065f86f7664fc23339fc1c1fac", size = 181814, upload-time = "2025-09-25T21:32:35.712Z" },
+    { url = "https://files.pythonhosted.org/packages/bd/9c/4d95bb87eb2063d20db7b60faa3840c1b18025517ae857371c4dd55a6b3a/pyyaml-6.0.3-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:34d5fcd24b8445fadc33f9cf348c1047101756fd760b4dacb5c3e99755703310", size = 173809, upload-time = "2025-09-25T21:32:36.789Z" },
+    { url = "https://files.pythonhosted.org/packages/92/b5/47e807c2623074914e29dabd16cbbdd4bf5e9b2db9f8090fa64411fc5382/pyyaml-6.0.3-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:501a031947e3a9025ed4405a168e6ef5ae3126c59f90ce0cd6f2bfc477be31b7", size = 766454, upload-time = "2025-09-25T21:32:37.966Z" },
+    { url = "https://files.pythonhosted.org/packages/02/9e/e5e9b168be58564121efb3de6859c452fccde0ab093d8438905899a3a483/pyyaml-6.0.3-cp314-cp314-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:b3bc83488de33889877a0f2543ade9f70c67d66d9ebb4ac959502e12de895788", size = 836355, upload-time = "2025-09-25T21:32:39.178Z" },
+    { url = "https://files.pythonhosted.org/packages/88/f9/16491d7ed2a919954993e48aa941b200f38040928474c9e85ea9e64222c3/pyyaml-6.0.3-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:c458b6d084f9b935061bc36216e8a69a7e293a2f1e68bf956dcd9e6cbcd143f5", size = 794175, upload-time = "2025-09-25T21:32:40.865Z" },
+    { url = "https://files.pythonhosted.org/packages/dd/3f/5989debef34dc6397317802b527dbbafb2b4760878a53d4166579111411e/pyyaml-6.0.3-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:7c6610def4f163542a622a73fb39f534f8c101d690126992300bf3207eab9764", size = 755228, upload-time = "2025-09-25T21:32:42.084Z" },
+    { url = "https://files.pythonhosted.org/packages/d7/ce/af88a49043cd2e265be63d083fc75b27b6ed062f5f9fd6cdc223ad62f03e/pyyaml-6.0.3-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:5190d403f121660ce8d1d2c1bb2ef1bd05b5f68533fc5c2ea899bd15f4399b35", size = 789194, upload-time = "2025-09-25T21:32:43.362Z" },
+    { url = "https://files.pythonhosted.org/packages/23/20/bb6982b26a40bb43951265ba29d4c246ef0ff59c9fdcdf0ed04e0687de4d/pyyaml-6.0.3-cp314-cp314-win_amd64.whl", hash = "sha256:4a2e8cebe2ff6ab7d1050ecd59c25d4c8bd7e6f400f5f82b96557ac0abafd0ac", size = 156429, upload-time = "2025-09-25T21:32:57.844Z" },
+    { url = "https://files.pythonhosted.org/packages/f4/f4/a4541072bb9422c8a883ab55255f918fa378ecf083f5b85e87fc2b4eda1b/pyyaml-6.0.3-cp314-cp314-win_arm64.whl", hash = "sha256:93dda82c9c22deb0a405ea4dc5f2d0cda384168e466364dec6255b293923b2f3", size = 143912, upload-time = "2025-09-25T21:32:59.247Z" },
+    { url = "https://files.pythonhosted.org/packages/7c/f9/07dd09ae774e4616edf6cda684ee78f97777bdd15847253637a6f052a62f/pyyaml-6.0.3-cp314-cp314t-macosx_10_13_x86_64.whl", hash = "sha256:02893d100e99e03eda1c8fd5c441d8c60103fd175728e23e431db1b589cf5ab3", size = 189108, upload-time = "2025-09-25T21:32:44.377Z" },
+    { url = "https://files.pythonhosted.org/packages/4e/78/8d08c9fb7ce09ad8c38ad533c1191cf27f7ae1effe5bb9400a46d9437fcf/pyyaml-6.0.3-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:c1ff362665ae507275af2853520967820d9124984e0f7466736aea23d8611fba", size = 183641, upload-time = "2025-09-25T21:32:45.407Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/5b/3babb19104a46945cf816d047db2788bcaf8c94527a805610b0289a01c6b/pyyaml-6.0.3-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:6adc77889b628398debc7b65c073bcb99c4a0237b248cacaf3fe8a557563ef6c", size = 831901, upload-time = "2025-09-25T21:32:48.83Z" },
+    { url = "https://files.pythonhosted.org/packages/8b/cc/dff0684d8dc44da4d22a13f35f073d558c268780ce3c6ba1b87055bb0b87/pyyaml-6.0.3-cp314-cp314t-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:a80cb027f6b349846a3bf6d73b5e95e782175e52f22108cfa17876aaeff93702", size = 861132, upload-time = "2025-09-25T21:32:50.149Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/5e/f77dc6b9036943e285ba76b49e118d9ea929885becb0a29ba8a7c75e29fe/pyyaml-6.0.3-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:00c4bdeba853cc34e7dd471f16b4114f4162dc03e6b7afcc2128711f0eca823c", size = 839261, upload-time = "2025-09-25T21:32:51.808Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/88/a9db1376aa2a228197c58b37302f284b5617f56a5d959fd1763fb1675ce6/pyyaml-6.0.3-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:66e1674c3ef6f541c35191caae2d429b967b99e02040f5ba928632d9a7f0f065", size = 805272, upload-time = "2025-09-25T21:32:52.941Z" },
+    { url = "https://files.pythonhosted.org/packages/da/92/1446574745d74df0c92e6aa4a7b0b3130706a4142b2d1a5869f2eaa423c6/pyyaml-6.0.3-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:16249ee61e95f858e83976573de0f5b2893b3677ba71c9dd36b9cf8be9ac6d65", size = 829923, upload-time = "2025-09-25T21:32:54.537Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/7a/1c7270340330e575b92f397352af856a8c06f230aa3e76f86b39d01b416a/pyyaml-6.0.3-cp314-cp314t-win_amd64.whl", hash = "sha256:4ad1906908f2f5ae4e5a8ddfce73c320c2a1429ec52eafd27138b7f1cbe341c9", size = 174062, upload-time = "2025-09-25T21:32:55.767Z" },
+    { url = "https://files.pythonhosted.org/packages/f1/12/de94a39c2ef588c7e6455cfbe7343d3b2dc9d6b6b2f40c4c6565744c873d/pyyaml-6.0.3-cp314-cp314t-win_arm64.whl", hash = "sha256:ebc55a14a21cb14062aa4162f906cd962b28e2e9ea38f9b4391244cd8de4ae0b", size = 149341, upload-time = "2025-09-25T21:32:56.828Z" },
+]
+
+[[package]]
+name = "requests"
+version = "2.33.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "certifi" },
+    { name = "charset-normalizer" },
+    { name = "idna" },
+    { name = "urllib3" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/5f/a4/98b9c7c6428a668bf7e42ebb7c79d576a1c3c1e3ae2d47e674b468388871/requests-2.33.1.tar.gz", hash = "sha256:18817f8c57c6263968bc123d237e3b8b08ac046f5456bd1e307ee8f4250d3517", size = 134120, upload-time = "2026-03-30T16:09:15.531Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d7/8e/7540e8a2036f79a125c1d2ebadf69ed7901608859186c856fa0388ef4197/requests-2.33.1-py3-none-any.whl", hash = "sha256:4e6d1ef462f3626a1f0a0a9c42dd93c63bad33f9f1c1937509b8c5c8718ab56a", size = 64947, upload-time = "2026-03-30T16:09:13.83Z" },
+]
+
+[[package]]
+name = "rich"
+version = "14.3.4"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "markdown-it-py" },
+    { name = "pygments" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/e9/67/cae617f1351490c25a4b8ac3b8b63a4dda609295d8222bad12242dfdc629/rich-14.3.4.tar.gz", hash = "sha256:817e02727f2b25b40ef56f5aa2217f400c8489f79ca8f46ea2b70dd5e14558a9", size = 230524, upload-time = "2026-04-11T02:57:45.419Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b3/76/6d163cfac87b632216f71879e6b2cf17163f773ff59c00b5ff4900a80fa3/rich-14.3.4-py3-none-any.whl", hash = "sha256:07e7adb4690f68864777b1450859253bed81a99a31ac321ac1817b2313558952", size = 310480, upload-time = "2026-04-11T02:57:47.484Z" },
+]
+
+[[package]]
+name = "ruff"
+version = "0.15.8"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/14/b0/73cf7550861e2b4824950b8b52eebdcc5adc792a00c514406556c5b80817/ruff-0.15.8.tar.gz", hash = "sha256:995f11f63597ee362130d1d5a327a87cb6f3f5eae3094c620bcc632329a4d26e", size = 4610921, upload-time = "2026-03-26T18:39:38.675Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/4a/92/c445b0cd6da6e7ae51e954939cb69f97e008dbe750cfca89b8cedc081be7/ruff-0.15.8-py3-none-linux_armv6l.whl", hash = "sha256:cbe05adeba76d58162762d6b239c9056f1a15a55bd4b346cfd21e26cd6ad7bc7", size = 10527394, upload-time = "2026-03-26T18:39:41.566Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/92/f1c662784d149ad1414cae450b082cf736430c12ca78367f20f5ed569d65/ruff-0.15.8-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:d3e3d0b6ba8dca1b7ef9ab80a28e840a20070c4b62e56d675c24f366ef330570", size = 10905693, upload-time = "2026-03-26T18:39:30.364Z" },
+    { url = "https://files.pythonhosted.org/packages/ca/f2/7a631a8af6d88bcef997eb1bf87cc3da158294c57044aafd3e17030613de/ruff-0.15.8-py3-none-macosx_11_0_arm64.whl", hash = "sha256:6ee3ae5c65a42f273f126686353f2e08ff29927b7b7e203b711514370d500de3", size = 10323044, upload-time = "2026-03-26T18:39:33.37Z" },
+    { url = "https://files.pythonhosted.org/packages/67/18/1bf38e20914a05e72ef3b9569b1d5c70a7ef26cd188d69e9ca8ef588d5bf/ruff-0.15.8-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:fdce027ada77baa448077ccc6ebb2fa9c3c62fd110d8659d601cf2f475858d94", size = 10629135, upload-time = "2026-03-26T18:39:44.142Z" },
+    { url = "https://files.pythonhosted.org/packages/d2/e9/138c150ff9af60556121623d41aba18b7b57d95ac032e177b6a53789d279/ruff-0.15.8-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:12e617fc01a95e5821648a6df341d80456bd627bfab8a829f7cfc26a14a4b4a3", size = 10348041, upload-time = "2026-03-26T18:39:52.178Z" },
+    { url = "https://files.pythonhosted.org/packages/02/f1/5bfb9298d9c323f842c5ddeb85f1f10ef51516ac7a34ba446c9347d898df/ruff-0.15.8-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:432701303b26416d22ba696c39f2c6f12499b89093b61360abc34bcc9bf07762", size = 11121987, upload-time = "2026-03-26T18:39:55.195Z" },
+    { url = "https://files.pythonhosted.org/packages/10/11/6da2e538704e753c04e8d86b1fc55712fdbdcc266af1a1ece7a51fff0d10/ruff-0.15.8-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:d910ae974b7a06a33a057cb87d2a10792a3b2b3b35e33d2699fdf63ec8f6b17a", size = 11951057, upload-time = "2026-03-26T18:39:19.18Z" },
+    { url = "https://files.pythonhosted.org/packages/83/f0/c9208c5fd5101bf87002fed774ff25a96eea313d305f1e5d5744698dc314/ruff-0.15.8-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:2033f963c43949d51e6fdccd3946633c6b37c484f5f98c3035f49c27395a8ab8", size = 11464613, upload-time = "2026-03-26T18:40:06.301Z" },
+    { url = "https://files.pythonhosted.org/packages/f8/22/d7f2fabdba4fae9f3b570e5605d5eb4500dcb7b770d3217dca4428484b17/ruff-0.15.8-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:0f29b989a55572fb885b77464cf24af05500806ab4edf9a0fd8977f9759d85b1", size = 11257557, upload-time = "2026-03-26T18:39:57.972Z" },
+    { url = "https://files.pythonhosted.org/packages/71/8c/382a9620038cf6906446b23ce8632ab8c0811b8f9d3e764f58bedd0c9a6f/ruff-0.15.8-py3-none-manylinux_2_31_riscv64.whl", hash = "sha256:ac51d486bf457cdc985a412fb1801b2dfd1bd8838372fc55de64b1510eff4bec", size = 11169440, upload-time = "2026-03-26T18:39:22.205Z" },
+    { url = "https://files.pythonhosted.org/packages/4d/0d/0994c802a7eaaf99380085e4e40c845f8e32a562e20a38ec06174b52ef24/ruff-0.15.8-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:c9861eb959edab053c10ad62c278835ee69ca527b6dcd72b47d5c1e5648964f6", size = 10605963, upload-time = "2026-03-26T18:39:46.682Z" },
+    { url = "https://files.pythonhosted.org/packages/19/aa/d624b86f5b0aad7cef6bbf9cd47a6a02dfdc4f72c92a337d724e39c9d14b/ruff-0.15.8-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:8d9a5b8ea13f26ae90838afc33f91b547e61b794865374f114f349e9036835fb", size = 10357484, upload-time = "2026-03-26T18:39:49.176Z" },
+    { url = "https://files.pythonhosted.org/packages/35/c3/e0b7835d23001f7d999f3895c6b569927c4d39912286897f625736e1fd04/ruff-0.15.8-py3-none-musllinux_1_2_i686.whl", hash = "sha256:c2a33a529fb3cbc23a7124b5c6ff121e4d6228029cba374777bd7649cc8598b8", size = 10830426, upload-time = "2026-03-26T18:40:03.702Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/51/ab20b322f637b369383adc341d761eaaa0f0203d6b9a7421cd6e783d81b9/ruff-0.15.8-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:75e5cd06b1cf3f47a3996cfc999226b19aa92e7cce682dcd62f80d7035f98f49", size = 11345125, upload-time = "2026-03-26T18:39:27.799Z" },
+    { url = "https://files.pythonhosted.org/packages/37/e6/90b2b33419f59d0f2c4c8a48a4b74b460709a557e8e0064cf33ad894f983/ruff-0.15.8-py3-none-win32.whl", hash = "sha256:bc1f0a51254ba21767bfa9a8b5013ca8149dcf38092e6a9eb704d876de94dc34", size = 10571959, upload-time = "2026-03-26T18:39:36.117Z" },
+    { url = "https://files.pythonhosted.org/packages/1f/a2/ef467cb77099062317154c63f234b8a7baf7cb690b99af760c5b68b9ee7f/ruff-0.15.8-py3-none-win_amd64.whl", hash = "sha256:04f79eff02a72db209d47d665ba7ebcad609d8918a134f86cb13dd132159fc89", size = 11743893, upload-time = "2026-03-26T18:39:25.01Z" },
+    { url = "https://files.pythonhosted.org/packages/15/e2/77be4fff062fa78d9b2a4dea85d14785dac5f1d0c1fb58ed52331f0ebe28/ruff-0.15.8-py3-none-win_arm64.whl", hash = "sha256:cf891fa8e3bb430c0e7fac93851a5978fc99c8fa2c053b57b118972866f8e5f2", size = 11048175, upload-time = "2026-03-26T18:40:01.06Z" },
+]
+
+[[package]]
+name = "sortedcontainers"
+version = "2.4.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/e8/c4/ba2f8066cceb6f23394729afe52f3bf7adec04bf9ed2c820b39e19299111/sortedcontainers-2.4.0.tar.gz", hash = "sha256:25caa5a06cc30b6b83d11423433f65d1f9d76c4c6a0c90e3379eaa43b9bfdb88", size = 30594, upload-time = "2021-05-16T22:03:42.897Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/32/46/9cb0e58b2deb7f82b84065f37f3bffeb12413f947f9388e4cac22c4621ce/sortedcontainers-2.4.0-py2.py3-none-any.whl", hash = "sha256:a163dcaede0f1c021485e957a39245190e74249897e2ae4b2aa38595db237ee0", size = 29575, upload-time = "2021-05-16T22:03:41.177Z" },
+]
+
+[[package]]
+name = "stevedore"
+version = "5.7.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/a2/6d/90764092216fa560f6587f83bb70113a8ba510ba436c6476a2b47359057c/stevedore-5.7.0.tar.gz", hash = "sha256:31dd6fe6b3cbe921e21dcefabc9a5f1cf848cf538a1f27543721b8ca09948aa3", size = 516200, upload-time = "2026-02-20T13:27:06.765Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/69/06/36d260a695f383345ab5bbc3fd447249594ae2fa8dfd19c533d5ae23f46b/stevedore-5.7.0-py3-none-any.whl", hash = "sha256:fd25efbb32f1abb4c9e502f385f0018632baac11f9ee5d1b70f88cc5e22ad4ed", size = 54483, upload-time = "2026-02-20T13:27:05.561Z" },
+]
+
+[[package]]
+name = "tenacity"
+version = "9.1.4"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/47/c6/ee486fd809e357697ee8a44d3d69222b344920433d3b6666ccd9b374630c/tenacity-9.1.4.tar.gz", hash = "sha256:adb31d4c263f2bd041081ab33b498309a57c77f9acf2db65aadf0898179cf93a", size = 49413, upload-time = "2026-02-07T10:45:33.841Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d7/c1/eb8f9debc45d3b7918a32ab756658a0904732f75e555402972246b0b8e71/tenacity-9.1.4-py3-none-any.whl", hash = "sha256:6095a360c919085f28c6527de529e76a06ad89b23659fa881ae0649b867a9d55", size = 28926, upload-time = "2026-02-07T10:45:32.24Z" },
+]
+
+[[package]]
+name = "tomli"
+version = "2.4.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/22/de/48c59722572767841493b26183a0d1cc411d54fd759c5607c4590b6563a6/tomli-2.4.1.tar.gz", hash = "sha256:7c7e1a961a0b2f2472c1ac5b69affa0ae1132c39adcb67aba98568702b9cc23f", size = 17543, upload-time = "2026-03-25T20:22:03.828Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/3c/fb/9a5c8d27dbab540869f7c1f8eb0abb3244189ce780ba9cd73f3770662072/tomli-2.4.1-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:fd0409a3653af6c147209d267a0e4243f0ae46b011aa978b1080359fddc9b6cf", size = 155726, upload-time = "2026-03-25T20:21:42.23Z" },
+    { url = "https://files.pythonhosted.org/packages/62/05/d2f816630cc771ad836af54f5001f47a6f611d2d39535364f148b6a92d6b/tomli-2.4.1-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:a120733b01c45e9a0c34aeef92bf0cf1d56cfe81ed9d47d562f9ed591a9828ac", size = 149859, upload-time = "2026-03-25T20:21:43.386Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/48/66341bdb858ad9bd0ceab5a86f90eddab127cf8b046418009f2125630ecb/tomli-2.4.1-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:559db847dc486944896521f68d8190be1c9e719fced785720d2216fe7022b662", size = 244713, upload-time = "2026-03-25T20:21:44.474Z" },
+    { url = "https://files.pythonhosted.org/packages/df/6d/c5fad00d82b3c7a3ab6189bd4b10e60466f22cfe8a08a9394185c8a8111c/tomli-2.4.1-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:01f520d4f53ef97964a240a035ec2a869fe1a37dde002b57ebc4417a27ccd853", size = 252084, upload-time = "2026-03-25T20:21:45.62Z" },
+    { url = "https://files.pythonhosted.org/packages/00/71/3a69e86f3eafe8c7a59d008d245888051005bd657760e96d5fbfb0b740c2/tomli-2.4.1-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:7f94b27a62cfad8496c8d2513e1a222dd446f095fca8987fceef261225538a15", size = 247973, upload-time = "2026-03-25T20:21:46.937Z" },
+    { url = "https://files.pythonhosted.org/packages/67/50/361e986652847fec4bd5e4a0208752fbe64689c603c7ae5ea7cb16b1c0ca/tomli-2.4.1-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:ede3e6487c5ef5d28634ba3f31f989030ad6af71edfb0055cbbd14189ff240ba", size = 256223, upload-time = "2026-03-25T20:21:48.467Z" },
+    { url = "https://files.pythonhosted.org/packages/8c/9a/b4173689a9203472e5467217e0154b00e260621caa227b6fa01feab16998/tomli-2.4.1-cp314-cp314-win32.whl", hash = "sha256:3d48a93ee1c9b79c04bb38772ee1b64dcf18ff43085896ea460ca8dec96f35f6", size = 98973, upload-time = "2026-03-25T20:21:49.526Z" },
+    { url = "https://files.pythonhosted.org/packages/14/58/640ac93bf230cd27d002462c9af0d837779f8773bc03dee06b5835208214/tomli-2.4.1-cp314-cp314-win_amd64.whl", hash = "sha256:88dceee75c2c63af144e456745e10101eb67361050196b0b6af5d717254dddf7", size = 109082, upload-time = "2026-03-25T20:21:50.506Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/2f/702d5e05b227401c1068f0d386d79a589bb12bf64c3d2c72ce0631e3bc49/tomli-2.4.1-cp314-cp314-win_arm64.whl", hash = "sha256:b8c198f8c1805dc42708689ed6864951fd2494f924149d3e4bce7710f8eb5232", size = 96490, upload-time = "2026-03-25T20:21:51.474Z" },
+    { url = "https://files.pythonhosted.org/packages/45/4b/b877b05c8ba62927d9865dd980e34a755de541eb65fffba52b4cc495d4d2/tomli-2.4.1-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:d4d8fe59808a54658fcc0160ecfb1b30f9089906c50b23bcb4c69eddc19ec2b4", size = 164263, upload-time = "2026-03-25T20:21:52.543Z" },
+    { url = "https://files.pythonhosted.org/packages/24/79/6ab420d37a270b89f7195dec5448f79400d9e9c1826df982f3f8e97b24fd/tomli-2.4.1-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:7008df2e7655c495dd12d2a4ad038ff878d4ca4b81fccaf82b714e07eae4402c", size = 160736, upload-time = "2026-03-25T20:21:53.674Z" },
+    { url = "https://files.pythonhosted.org/packages/02/e0/3630057d8eb170310785723ed5adcdfb7d50cb7e6455f85ba8a3deed642b/tomli-2.4.1-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:1d8591993e228b0c930c4bb0db464bdad97b3289fb981255d6c9a41aedc84b2d", size = 270717, upload-time = "2026-03-25T20:21:55.129Z" },
+    { url = "https://files.pythonhosted.org/packages/7a/b4/1613716072e544d1a7891f548d8f9ec6ce2faf42ca65acae01d76ea06bb0/tomli-2.4.1-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:734e20b57ba95624ecf1841e72b53f6e186355e216e5412de414e3c51e5e3c41", size = 278461, upload-time = "2026-03-25T20:21:56.228Z" },
+    { url = "https://files.pythonhosted.org/packages/05/38/30f541baf6a3f6df77b3df16b01ba319221389e2da59427e221ef417ac0c/tomli-2.4.1-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:8a650c2dbafa08d42e51ba0b62740dae4ecb9338eefa093aa5c78ceb546fcd5c", size = 274855, upload-time = "2026-03-25T20:21:57.653Z" },
+    { url = "https://files.pythonhosted.org/packages/77/a3/ec9dd4fd2c38e98de34223b995a3b34813e6bdadf86c75314c928350ed14/tomli-2.4.1-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:504aa796fe0569bb43171066009ead363de03675276d2d121ac1a4572397870f", size = 283144, upload-time = "2026-03-25T20:21:59.089Z" },
+    { url = "https://files.pythonhosted.org/packages/ef/be/605a6261cac79fba2ec0c9827e986e00323a1945700969b8ee0b30d85453/tomli-2.4.1-cp314-cp314t-win32.whl", hash = "sha256:b1d22e6e9387bf4739fbe23bfa80e93f6b0373a7f1b96c6227c32bef95a4d7a8", size = 108683, upload-time = "2026-03-25T20:22:00.214Z" },
+    { url = "https://files.pythonhosted.org/packages/12/64/da524626d3b9cc40c168a13da8335fe1c51be12c0a63685cc6db7308daae/tomli-2.4.1-cp314-cp314t-win_amd64.whl", hash = "sha256:2c1c351919aca02858f740c6d33adea0c5deea37f9ecca1cc1ef9e884a619d26", size = 121196, upload-time = "2026-03-25T20:22:01.169Z" },
+    { url = "https://files.pythonhosted.org/packages/5a/cd/e80b62269fc78fc36c9af5a6b89c835baa8af28ff5ad28c7028d60860320/tomli-2.4.1-cp314-cp314t-win_arm64.whl", hash = "sha256:eab21f45c7f66c13f2a9e0e1535309cee140182a9cdae1e041d02e47291e8396", size = 100393, upload-time = "2026-03-25T20:22:02.137Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/61/cceae43728b7de99d9b847560c262873a1f6c98202171fd5ed62640b494b/tomli-2.4.1-py3-none-any.whl", hash = "sha256:0d85819802132122da43cb86656f8d1f8c6587d54ae7dcaf30e90533028b49fe", size = 14583, upload-time = "2026-03-25T20:22:03.012Z" },
+]
+
+[[package]]
+name = "tomli-w"
+version = "1.2.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/19/75/241269d1da26b624c0d5e110e8149093c759b7a286138f4efd61a60e75fe/tomli_w-1.2.0.tar.gz", hash = "sha256:2dd14fac5a47c27be9cd4c976af5a12d87fb1f0b4512f81d69cce3b35ae25021", size = 7184, upload-time = "2025-01-15T12:07:24.262Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c7/18/c86eb8e0202e32dd3df50d43d7ff9854f8e0603945ff398974c1d91ac1ef/tomli_w-1.2.0-py3-none-any.whl", hash = "sha256:188306098d013b691fcadc011abd66727d3c414c571bb01b1a174ba8c983cf90", size = 6675, upload-time = "2025-01-15T12:07:22.074Z" },
+]
+
+[[package]]
+name = "typing-extensions"
+version = "4.15.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/72/94/1a15dd82efb362ac84269196e94cf00f187f7ed21c242792a923cdb1c61f/typing_extensions-4.15.0.tar.gz", hash = "sha256:0cea48d173cc12fa28ecabc3b837ea3cf6f38c6d1136f85cbaaf598984861466", size = 109391, upload-time = "2025-08-25T13:49:26.313Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/18/67/36e9267722cc04a6b9f15c7f3441c2363321a3ea07da7ae0c0707beb2a9c/typing_extensions-4.15.0-py3-none-any.whl", hash = "sha256:f0fa19c6845758ab08074a0cfa8b7aecb71c999ca73d62883bc25cc018c4e548", size = 44614, upload-time = "2025-08-25T13:49:24.86Z" },
+]
+
+[[package]]
+name = "typing-inspection"
+version = "0.4.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/55/e3/70399cb7dd41c10ac53367ae42139cf4b1ca5f36bb3dc6c9d33acdb43655/typing_inspection-0.4.2.tar.gz", hash = "sha256:ba561c48a67c5958007083d386c3295464928b01faa735ab8547c5692e87f464", size = 75949, upload-time = "2025-10-01T02:14:41.687Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/dc/9b/47798a6c91d8bdb567fe2698fe81e0c6b7cb7ef4d13da4114b41d239f65d/typing_inspection-0.4.2-py3-none-any.whl", hash = "sha256:4ed1cacbdc298c220f1bd249ed5287caa16f34d44ef4e9c3d0cbad5b521545e7", size = 14611, upload-time = "2025-10-01T02:14:40.154Z" },
+]
+
+[[package]]
+name = "tzdata"
+version = "2026.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/19/f5/cd531b2d15a671a40c0f66cf06bc3570a12cd56eef98960068ebbad1bf5a/tzdata-2026.1.tar.gz", hash = "sha256:67658a1903c75917309e753fdc349ac0efd8c27db7a0cb406a25be4840f87f98", size = 197639, upload-time = "2026-04-03T11:25:22.002Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b0/70/d460bd685a170790ec89317e9bd33047988e4bce507b831f5db771e142de/tzdata-2026.1-py2.py3-none-any.whl", hash = "sha256:4b1d2be7ac37ceafd7327b961aa3a54e467efbdb563a23655fbfe0d39cfc42a9", size = 348952, upload-time = "2026-04-03T11:25:20.313Z" },
+]
+
+[[package]]
+name = "tzlocal"
+version = "5.3.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "tzdata", marker = "sys_platform == 'win32'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/8b/2e/c14812d3d4d9cd1773c6be938f89e5735a1f11a9f184ac3639b93cef35d5/tzlocal-5.3.1.tar.gz", hash = "sha256:cceffc7edecefea1f595541dbd6e990cb1ea3d19bf01b2809f362a03dd7921fd", size = 30761, upload-time = "2025-03-05T21:17:41.549Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c2/14/e2a54fabd4f08cd7af1c07030603c3356b74da07f7cc056e600436edfa17/tzlocal-5.3.1-py3-none-any.whl", hash = "sha256:eb1a66c3ef5847adf7a834f1be0800581b683b5608e74f86ecbcef8ab91bb85d", size = 18026, upload-time = "2025-03-05T21:17:39.857Z" },
+]
+
+[[package]]
+name = "urllib3"
+version = "2.6.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/c7/24/5f1b3bdffd70275f6661c76461e25f024d5a38a46f04aaca912426a2b1d3/urllib3-2.6.3.tar.gz", hash = "sha256:1b62b6884944a57dbe321509ab94fd4d3b307075e0c2eae991ac71ee15ad38ed", size = 435556, upload-time = "2026-01-07T16:24:43.925Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/39/08/aaaad47bc4e9dc8c725e68f9d04865dbcb2052843ff09c97b08904852d84/urllib3-2.6.3-py3-none-any.whl", hash = "sha256:bf272323e553dfb2e87d9bfd225ca7b0f467b919d7bbd355436d3fd37cb0acd4", size = 131584, upload-time = "2026-01-07T16:24:42.685Z" },
+]
+
+[[package]]
+name = "usdt-monitor-bot"
+version = "0.1.0"
+source = { editable = "." }
+dependencies = [
+    { name = "aiogram" },
+    { name = "apscheduler" },
+    { name = "python-dotenv" },
+    { name = "tenacity" },
+]
+
+[package.optional-dependencies]
+dev = [
+    { name = "ruff" },
+]
+security = [
+    { name = "bandit" },
+    { name = "pip-audit" },
+]
+test = [
+    { name = "pytest" },
+    { name = "pytest-asyncio" },
+    { name = "pytest-mock" },
+    { name = "pytest-xdist" },
+]
+
+[package.metadata]
+requires-dist = [
+    { name = "aiogram", specifier = "==3.26.0" },
+    { name = "apscheduler", specifier = "==3.11.2" },
+    { name = "bandit", marker = "extra == 'security'", specifier = "==1.9.4" },
+    { name = "pip-audit", marker = "extra == 'security'", specifier = "==2.10.0" },
+    { name = "pytest", marker = "extra == 'test'", specifier = "==9.0.2" },
+    { name = "pytest-asyncio", marker = "extra == 'test'", specifier = "==1.3.0" },
+    { name = "pytest-mock", marker = "extra == 'test'", specifier = "==3.15.1" },
+    { name = "pytest-xdist", marker = "extra == 'test'", specifier = "==3.8.0" },
+    { name = "python-dotenv", specifier = "==1.2.2" },
+    { name = "ruff", marker = "extra == 'dev'", specifier = "==0.15.8" },
+    { name = "tenacity", specifier = "==9.1.4" },
+]
+provides-extras = ["test", "dev", "security"]
+
+[[package]]
+name = "yarl"
+version = "1.23.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "idna" },
+    { name = "multidict" },
+    { name = "propcache" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/23/6e/beb1beec874a72f23815c1434518bfc4ed2175065173fb138c3705f658d4/yarl-1.23.0.tar.gz", hash = "sha256:53b1ea6ca88ebd4420379c330aea57e258408dd0df9af0992e5de2078dc9f5d5", size = 194676, upload-time = "2026-03-01T22:07:53.373Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/90/98/b85a038d65d1b92c3903ab89444f48d3cee490a883477b716d7a24b1a78c/yarl-1.23.0-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:21d1b7305a71a15b4794b5ff22e8eef96ff4a6d7f9657155e5aa419444b28912", size = 124455, upload-time = "2026-03-01T22:06:43.615Z" },
+    { url = "https://files.pythonhosted.org/packages/39/54/bc2b45559f86543d163b6e294417a107bb87557609007c007ad889afec18/yarl-1.23.0-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:85610b4f27f69984932a7abbe52703688de3724d9f72bceb1cca667deff27474", size = 86752, upload-time = "2026-03-01T22:06:45.425Z" },
+    { url = "https://files.pythonhosted.org/packages/24/f9/e8242b68362bffe6fb536c8db5076861466fc780f0f1b479fc4ffbebb128/yarl-1.23.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:23f371bd662cf44a7630d4d113101eafc0cfa7518a2760d20760b26021454719", size = 86291, upload-time = "2026-03-01T22:06:46.974Z" },
+    { url = "https://files.pythonhosted.org/packages/ea/d8/d1cb2378c81dd729e98c716582b1ccb08357e8488e4c24714658cc6630e8/yarl-1.23.0-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:c4a80f77dc1acaaa61f0934176fccca7096d9b1ff08c8ba9cddf5ae034a24319", size = 99026, upload-time = "2026-03-01T22:06:48.459Z" },
+    { url = "https://files.pythonhosted.org/packages/0a/ff/7196790538f31debe3341283b5b0707e7feb947620fc5e8236ef28d44f72/yarl-1.23.0-cp314-cp314-manylinux2014_armv7l.manylinux_2_17_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:bd654fad46d8d9e823afbb4f87c79160b5a374ed1ff5bde24e542e6ba8f41434", size = 92355, upload-time = "2026-03-01T22:06:50.306Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/56/25d58c3eddde825890a5fe6aa1866228377354a3c39262235234ab5f616b/yarl-1.23.0-cp314-cp314-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:682bae25f0a0dd23a056739f23a134db9f52a63e2afd6bfb37ddc76292bbd723", size = 106417, upload-time = "2026-03-01T22:06:52.1Z" },
+    { url = "https://files.pythonhosted.org/packages/51/8a/882c0e7bc8277eb895b31bce0138f51a1ba551fc2e1ec6753ffc1e7c1377/yarl-1.23.0-cp314-cp314-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:a82836cab5f197a0514235aaf7ffccdc886ccdaa2324bc0aafdd4ae898103039", size = 106422, upload-time = "2026-03-01T22:06:54.424Z" },
+    { url = "https://files.pythonhosted.org/packages/42/2b/fef67d616931055bf3d6764885990a3ac647d68734a2d6a9e1d13de437a2/yarl-1.23.0-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:1c57676bdedc94cd3bc37724cf6f8cd2779f02f6aba48de45feca073e714fe52", size = 101915, upload-time = "2026-03-01T22:06:55.895Z" },
+    { url = "https://files.pythonhosted.org/packages/18/6a/530e16aebce27c5937920f3431c628a29a4b6b430fab3fd1c117b26ff3f6/yarl-1.23.0-cp314-cp314-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:c7f8dc16c498ff06497c015642333219871effba93e4a2e8604a06264aca5c5c", size = 100690, upload-time = "2026-03-01T22:06:58.21Z" },
+    { url = "https://files.pythonhosted.org/packages/88/08/93749219179a45e27b036e03260fda05190b911de8e18225c294ac95bbc9/yarl-1.23.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:5ee586fb17ff8f90c91cf73c6108a434b02d69925f44f5f8e0d7f2f260607eae", size = 98750, upload-time = "2026-03-01T22:06:59.794Z" },
+    { url = "https://files.pythonhosted.org/packages/d9/cf/ea424a004969f5d81a362110a6ac1496d79efdc6d50c2c4b2e3ea0fc2519/yarl-1.23.0-cp314-cp314-musllinux_1_2_armv7l.whl", hash = "sha256:17235362f580149742739cc3828b80e24029d08cbb9c4bda0242c7b5bc610a8e", size = 94685, upload-time = "2026-03-01T22:07:01.375Z" },
+    { url = "https://files.pythonhosted.org/packages/e2/b7/14341481fe568e2b0408bcf1484c652accafe06a0ade9387b5d3fd9df446/yarl-1.23.0-cp314-cp314-musllinux_1_2_ppc64le.whl", hash = "sha256:0793e2bd0cf14234983bbb371591e6bea9e876ddf6896cdcc93450996b0b5c85", size = 106009, upload-time = "2026-03-01T22:07:03.151Z" },
+    { url = "https://files.pythonhosted.org/packages/0a/e6/5c744a9b54f4e8007ad35bce96fbc9218338e84812d36f3390cea616881a/yarl-1.23.0-cp314-cp314-musllinux_1_2_riscv64.whl", hash = "sha256:3650dc2480f94f7116c364096bc84b1d602f44224ef7d5c7208425915c0475dd", size = 100033, upload-time = "2026-03-01T22:07:04.701Z" },
+    { url = "https://files.pythonhosted.org/packages/0c/23/e3bfc188d0b400f025bc49d99793d02c9abe15752138dcc27e4eaf0c4a9e/yarl-1.23.0-cp314-cp314-musllinux_1_2_s390x.whl", hash = "sha256:f40e782d49630ad384db66d4d8b73ff4f1b8955dc12e26b09a3e3af064b3b9d6", size = 106483, upload-time = "2026-03-01T22:07:06.231Z" },
+    { url = "https://files.pythonhosted.org/packages/72/42/f0505f949a90b3f8b7a363d6cbdf398f6e6c58946d85c6d3a3bc70595b26/yarl-1.23.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:94f8575fbdf81749008d980c17796097e645574a3b8c28ee313931068dad14fe", size = 102175, upload-time = "2026-03-01T22:07:08.4Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/65/b39290f1d892a9dd671d1c722014ca062a9c35d60885d57e5375db0404b5/yarl-1.23.0-cp314-cp314-win32.whl", hash = "sha256:c8aa34a5c864db1087d911a0b902d60d203ea3607d91f615acd3f3108ac32169", size = 83871, upload-time = "2026-03-01T22:07:09.968Z" },
+    { url = "https://files.pythonhosted.org/packages/a9/5b/9b92f54c784c26e2a422e55a8d2607ab15b7ea3349e28359282f84f01d43/yarl-1.23.0-cp314-cp314-win_amd64.whl", hash = "sha256:63e92247f383c85ab00dd0091e8c3fa331a96e865459f5ee80353c70a4a42d70", size = 89093, upload-time = "2026-03-01T22:07:11.501Z" },
+    { url = "https://files.pythonhosted.org/packages/e0/7d/8a84dc9381fd4412d5e7ff04926f9865f6372b4c2fd91e10092e65d29eb8/yarl-1.23.0-cp314-cp314-win_arm64.whl", hash = "sha256:70efd20be968c76ece7baa8dafe04c5be06abc57f754d6f36f3741f7aa7a208e", size = 83384, upload-time = "2026-03-01T22:07:13.069Z" },
+    { url = "https://files.pythonhosted.org/packages/dd/8d/d2fad34b1c08aa161b74394183daa7d800141aaaee207317e82c790b418d/yarl-1.23.0-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:9a18d6f9359e45722c064c97464ec883eb0e0366d33eda61cb19a244bf222679", size = 131019, upload-time = "2026-03-01T22:07:14.903Z" },
+    { url = "https://files.pythonhosted.org/packages/19/ff/33009a39d3ccf4b94d7d7880dfe17fb5816c5a4fe0096d9b56abceea9ac7/yarl-1.23.0-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:2803ed8b21ca47a43da80a6fd1ed3019d30061f7061daa35ac54f63933409412", size = 89894, upload-time = "2026-03-01T22:07:17.372Z" },
+    { url = "https://files.pythonhosted.org/packages/0c/f1/dab7ac5e7306fb79c0190766a3c00b4cb8d09a1f390ded68c85a5934faf5/yarl-1.23.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:394906945aa8b19fc14a61cf69743a868bb8c465efe85eee687109cc540b98f4", size = 89979, upload-time = "2026-03-01T22:07:19.361Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/b1/08e95f3caee1fad6e65017b9f26c1d79877b502622d60e517de01e72f95d/yarl-1.23.0-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:71d006bee8397a4a89f469b8deb22469fe7508132d3c17fa6ed871e79832691c", size = 95943, upload-time = "2026-03-01T22:07:21.266Z" },
+    { url = "https://files.pythonhosted.org/packages/c0/cc/6409f9018864a6aa186c61175b977131f373f1988e198e031236916e87e4/yarl-1.23.0-cp314-cp314t-manylinux2014_armv7l.manylinux_2_17_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:62694e275c93d54f7ccedcfef57d42761b2aad5234b6be1f3e3026cae4001cd4", size = 88786, upload-time = "2026-03-01T22:07:23.129Z" },
+    { url = "https://files.pythonhosted.org/packages/76/40/cc22d1d7714b717fde2006fad2ced5efe5580606cb059ae42117542122f3/yarl-1.23.0-cp314-cp314t-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:a31de1613658308efdb21ada98cbc86a97c181aa050ba22a808120bb5be3ab94", size = 101307, upload-time = "2026-03-01T22:07:24.689Z" },
+    { url = "https://files.pythonhosted.org/packages/8f/0d/476c38e85ddb4c6ec6b20b815bdd779aa386a013f3d8b85516feee55c8dc/yarl-1.23.0-cp314-cp314t-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:fb1e8b8d66c278b21d13b0a7ca22c41dd757a7c209c6b12c313e445c31dd3b28", size = 100904, upload-time = "2026-03-01T22:07:26.287Z" },
+    { url = "https://files.pythonhosted.org/packages/72/32/0abe4a76d59adf2081dcb0397168553ece4616ada1c54d1c49d8936c74f8/yarl-1.23.0-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:50f9d8d531dfb767c565f348f33dd5139a6c43f5cbdf3f67da40d54241df93f6", size = 97728, upload-time = "2026-03-01T22:07:27.906Z" },
+    { url = "https://files.pythonhosted.org/packages/b7/35/7b30f4810fba112f60f5a43237545867504e15b1c7647a785fbaf588fac2/yarl-1.23.0-cp314-cp314t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:575aa4405a656e61a540f4a80eaa5260f2a38fff7bfdc4b5f611840d76e9e277", size = 95964, upload-time = "2026-03-01T22:07:30.198Z" },
+    { url = "https://files.pythonhosted.org/packages/2d/86/ed7a73ab85ef00e8bb70b0cb5421d8a2a625b81a333941a469a6f4022828/yarl-1.23.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:041b1a4cefacf65840b4e295c6985f334ba83c30607441ae3cf206a0eed1a2e4", size = 95882, upload-time = "2026-03-01T22:07:32.132Z" },
+    { url = "https://files.pythonhosted.org/packages/19/90/d56967f61a29d8498efb7afb651e0b2b422a1e9b47b0ab5f4e40a19b699b/yarl-1.23.0-cp314-cp314t-musllinux_1_2_armv7l.whl", hash = "sha256:d38c1e8231722c4ce40d7593f28d92b5fc72f3e9774fe73d7e800ec32299f63a", size = 90797, upload-time = "2026-03-01T22:07:34.404Z" },
+    { url = "https://files.pythonhosted.org/packages/72/00/8b8f76909259f56647adb1011d7ed8b321bcf97e464515c65016a47ecdf0/yarl-1.23.0-cp314-cp314t-musllinux_1_2_ppc64le.whl", hash = "sha256:d53834e23c015ee83a99377db6e5e37d8484f333edb03bd15b4bc312cc7254fb", size = 101023, upload-time = "2026-03-01T22:07:35.953Z" },
+    { url = "https://files.pythonhosted.org/packages/ac/e2/cab11b126fb7d440281b7df8e9ddbe4851e70a4dde47a202b6642586b8d9/yarl-1.23.0-cp314-cp314t-musllinux_1_2_riscv64.whl", hash = "sha256:2e27c8841126e017dd2a054a95771569e6070b9ee1b133366d8b31beb5018a41", size = 96227, upload-time = "2026-03-01T22:07:37.594Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/9b/2c893e16bfc50e6b2edf76c1a9eb6cb0c744346197e74c65e99ad8d634d0/yarl-1.23.0-cp314-cp314t-musllinux_1_2_s390x.whl", hash = "sha256:76855800ac56f878847a09ce6dba727c93ca2d89c9e9d63002d26b916810b0a2", size = 100302, upload-time = "2026-03-01T22:07:39.334Z" },
+    { url = "https://files.pythonhosted.org/packages/28/ec/5498c4e3a6d5f1003beb23405671c2eb9cdbf3067d1c80f15eeafe301010/yarl-1.23.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:e09fd068c2e169a7070d83d3bde728a4d48de0549f975290be3c108c02e499b4", size = 98202, upload-time = "2026-03-01T22:07:41.717Z" },
+    { url = "https://files.pythonhosted.org/packages/fe/c3/cd737e2d45e70717907f83e146f6949f20cc23cd4bf7b2688727763aa458/yarl-1.23.0-cp314-cp314t-win32.whl", hash = "sha256:73309162a6a571d4cbd3b6a1dcc703c7311843ae0d1578df6f09be4e98df38d4", size = 90558, upload-time = "2026-03-01T22:07:43.433Z" },
+    { url = "https://files.pythonhosted.org/packages/e1/19/3774d162f6732d1cfb0b47b4140a942a35ca82bb19b6db1f80e9e7bdc8f8/yarl-1.23.0-cp314-cp314t-win_amd64.whl", hash = "sha256:4503053d296bc6e4cbd1fad61cf3b6e33b939886c4f249ba7c78b602214fabe2", size = 97610, upload-time = "2026-03-01T22:07:45.773Z" },
+    { url = "https://files.pythonhosted.org/packages/51/47/3fa2286c3cb162c71cdb34c4224d5745a1ceceb391b2bd9b19b668a8d724/yarl-1.23.0-cp314-cp314t-win_arm64.whl", hash = "sha256:44bb7bef4ea409384e3f8bc36c063d77ea1b8d4a5b2706956c0d6695f07dcc25", size = 86041, upload-time = "2026-03-01T22:07:49.026Z" },
+    { url = "https://files.pythonhosted.org/packages/69/68/c8739671f5699c7dc470580a4f821ef37c32c4cb0b047ce223a7f115757f/yarl-1.23.0-py3-none-any.whl", hash = "sha256:a2df6afe50dea8ae15fa34c9f824a3ee958d785fd5d089063d960bae1daa0a3f", size = 48288, upload-time = "2026-03-01T22:07:51.388Z" },
+]


### PR DESCRIPTION
## Summary
- Centralize `make_json_session_mock` in `conftest`, remove dead `checker` fixture; Blockscout/Moralis tests use shared helper.
- `test_checker`: reuse conftest mocks (`mock_db_manager`, `mock_etherscan_client`, `mock_notifier`), drop redundant asyncio markers/module mark where auto mode suffices.
- `test_notifier` / `test_etherscan`: strip redundant per-test `@pytest.mark.asyncio` and module pytestmark (mixed sync/async in etherscan).
- Remove unused `different_address` fixture; parametrize address validation in `test_utils`.
- Lockfile: `uv.lock` (dependency snapshot).

## Verification
- `pytest`
- `ruff check tests/`

Made with [Cursor](https://cursor.com)