### PR TITLE
fix: paginate Etherscan tokentx to stay within free-tier 1,000-record limit

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -5,9 +5,17 @@ on:
   pull_request:
     paths:
       - "**.py"
+      - "pyproject.toml"
+      - "uv.lock"
+      - ".github/workflows/security.yml"
   push:
     paths:
       - "**.py"
+      - "pyproject.toml"
+      - "uv.lock"
+      - ".github/workflows/security.yml"
+  schedule:
+    - cron: "0 6 * * 1"  # Every Monday at 06:00 UTC
   workflow_dispatch:
 
 concurrency:
@@ -34,7 +42,7 @@ jobs:
 
       - name: Install dependencies
         run: |
-          uv pip install --system -e ".[security]"
+          uv pip install --system -e ".[security,test]"
       - name: Run Bandit
         run: |
           bandit --baseline baseline.json -r usdt_monitor_bot/

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -41,7 +41,10 @@ jobs:
           enable-cache: true
 
       - name: Install dependencies
+        # Upgrade pip to >=26.1 to address CVE-2026-3219 in the runner's
+        # bundled pip (flagged by pip-audit below).
         run: |
+          uv pip install --system --upgrade 'pip>=26.1'
           uv pip install --system -e ".[security,test]"
       - name: Run Bandit
         run: |

--- a/tests/test_etherscan.py
+++ b/tests/test_etherscan.py
@@ -858,6 +858,9 @@ async def test_get_token_transactions_paginates_multiple_pages(
 
     assert len(result) == page_size + 3
     assert mock_aiohttp_session.get.call_count == 2
+    calls = mock_aiohttp_session.get.call_args_list
+    assert calls[0].kwargs["params"]["page"] == 1
+    assert calls[1].kwargs["params"]["page"] == 2
 
 
 async def test_get_token_transactions_no_transactions_found_on_second_page(
@@ -889,6 +892,9 @@ async def test_get_token_transactions_no_transactions_found_on_second_page(
 
     assert len(result) == page_size
     assert mock_aiohttp_session.get.call_count == 2
+    calls = mock_aiohttp_session.get.call_args_list
+    assert calls[0].kwargs["params"]["page"] == 1
+    assert calls[1].kwargs["params"]["page"] == 2
 
 
 async def test_get_token_transactions_page_and_offset_params_sent(

--- a/tests/test_etherscan.py
+++ b/tests/test_etherscan.py
@@ -799,3 +799,113 @@ async def test_get_contract_creation_blocks_api_error_returns_empty(
 
     result = await client.get_contract_creation_blocks(addrs)
     assert result == {addrs[0]: None, addrs[1]: None}
+
+
+# --- Pagination tests for get_token_transactions ---
+
+
+async def test_get_token_transactions_single_page(
+    etherscan_client_with_mocked_session, mock_aiohttp_session
+):
+    """A response with fewer than PAGE_SIZE records stops after one request."""
+    client = etherscan_client_with_mocked_session
+    mock_session_get = mock_aiohttp_session.get
+
+    mock_response = mock_aiohttp_session.get.return_value.__aenter__.return_value
+    mock_response.status = 200
+    mock_response.json = AsyncMock(
+        return_value={
+            "status": "1",
+            "message": "OK",
+            "result": [{"hash": f"0x{i}"} for i in range(5)],
+        }
+    )
+
+    result = await client.get_token_transactions("0xcontract", "0xaddress", 0)
+
+    assert len(result) == 5
+    assert mock_session_get.call_count == 1
+
+
+async def test_get_token_transactions_paginates_multiple_pages(
+    etherscan_client_with_mocked_session, mock_aiohttp_session
+):
+    """When page 1 returns PAGE_SIZE records, a second page is fetched."""
+    client = etherscan_client_with_mocked_session
+    page_size = client._TOKEN_TX_PAGE_SIZE
+
+    full_page = [{"hash": f"0x{i}"} for i in range(page_size)]
+    partial_page = [{"hash": f"0xlast{i}"} for i in range(3)]
+
+    # page 1: full page → trigger pagination; page 2: partial → stop
+    response1_ctx = AsyncMock()
+    response1 = AsyncMock(status=200)
+    response1.json = AsyncMock(
+        return_value={"status": "1", "message": "OK", "result": full_page}
+    )
+    response1_ctx.__aenter__.return_value = response1
+
+    response2_ctx = AsyncMock()
+    response2 = AsyncMock(status=200)
+    response2.json = AsyncMock(
+        return_value={"status": "1", "message": "OK", "result": partial_page}
+    )
+    response2_ctx.__aenter__.return_value = response2
+
+    mock_aiohttp_session.get.side_effect = [response1_ctx, response2_ctx]
+
+    result = await client.get_token_transactions("0xcontract", "0xaddress", 0)
+
+    assert len(result) == page_size + 3
+    assert mock_aiohttp_session.get.call_count == 2
+
+
+async def test_get_token_transactions_no_transactions_found_on_second_page(
+    etherscan_client_with_mocked_session, mock_aiohttp_session
+):
+    """'No transactions found' on page 2 (status=0) is treated as empty and stops pagination."""
+    client = etherscan_client_with_mocked_session
+    page_size = client._TOKEN_TX_PAGE_SIZE
+
+    full_page = [{"hash": f"0x{i}"} for i in range(page_size)]
+
+    response1_ctx = AsyncMock()
+    response1 = AsyncMock(status=200)
+    response1.json = AsyncMock(
+        return_value={"status": "1", "message": "OK", "result": full_page}
+    )
+    response1_ctx.__aenter__.return_value = response1
+
+    response2_ctx = AsyncMock()
+    response2 = AsyncMock(status=200)
+    response2.json = AsyncMock(
+        return_value={"status": "0", "message": "No transactions found", "result": []}
+    )
+    response2_ctx.__aenter__.return_value = response2
+
+    mock_aiohttp_session.get.side_effect = [response1_ctx, response2_ctx]
+
+    result = await client.get_token_transactions("0xcontract", "0xaddress", 0)
+
+    assert len(result) == page_size
+    assert mock_aiohttp_session.get.call_count == 2
+
+
+async def test_get_token_transactions_page_and_offset_params_sent(
+    etherscan_client_with_mocked_session, mock_aiohttp_session
+):
+    """Verify that page and offset query params are included in the request."""
+    client = etherscan_client_with_mocked_session
+
+    mock_response = mock_aiohttp_session.get.return_value.__aenter__.return_value
+    mock_response.status = 200
+    mock_response.json = AsyncMock(
+        return_value={"status": "1", "message": "OK", "result": []}
+    )
+
+    await client.get_token_transactions("0xcontract", "0xaddress", 0)
+
+    call_kwargs = mock_aiohttp_session.get.call_args
+    params = call_kwargs[1]["params"] if call_kwargs[1] else call_kwargs[0][1]
+    assert params["page"] == 1
+    assert params["offset"] == client._TOKEN_TX_PAGE_SIZE

--- a/usdt_monitor_bot/etherscan.py
+++ b/usdt_monitor_bot/etherscan.py
@@ -318,22 +318,18 @@ class EtherscanClient:
             self._rate_limiter.on_rate_limit()
             raise
 
-    @retry(
-        stop=stop_after_attempt(5),  # Attempt 5 times in total (1 initial + 4 retries)
-        wait=wait_exponential(
-            multiplier=1, min=1, max=10
-        ),  # Waits 1s, 2s, 4s, 8s (max is 10 but won't be reached with 4 retries after first failure)
-        retry=retry_if_exception_type(
-            (EtherscanRateLimitError, aiohttp.ClientError, asyncio.TimeoutError)
-        ),
-        before_sleep=before_sleep_log(logging.getLogger(__name__), logging.INFO),
-        reraise=True,  # Reraise the last exception if all retries fail
-    )
+    # Etherscan free tier caps at 1,000 records per request (effective July 1, 2026,
+    # reduced from 10,000). We use this as our page size and paginate automatically.
+    _TOKEN_TX_PAGE_SIZE = 1000
+
     async def get_token_transactions(
         self, contract_address: str, address: str, start_block: int = 0
     ) -> list[dict]:
         """
         Get token transactions for an address from a specific block number.
+
+        Paginates automatically through all pages using a page size of
+        _TOKEN_TX_PAGE_SIZE (1,000) to stay within Etherscan's free-tier limit.
 
         The API may return duplicate transaction hashes: the same tx can appear
         in multiple token responses, or multiple transfer events for one token in
@@ -352,6 +348,49 @@ class EtherscanClient:
             EtherscanError: For other API errors
         """
         await self._ensure_session()
+        all_results: list[dict] = []
+        page = 1
+        while True:
+            page_results = await self._get_token_transactions_page(
+                contract_address, address, start_block, page
+            )
+            all_results.extend(page_results)
+            if len(page_results) < self._TOKEN_TX_PAGE_SIZE:
+                break
+            page += 1
+        return all_results
+
+    @retry(
+        stop=stop_after_attempt(5),  # Attempt 5 times in total (1 initial + 4 retries)
+        wait=wait_exponential(
+            multiplier=1, min=1, max=10
+        ),  # Waits 1s, 2s, 4s, 8s (max is 10 but won't be reached with 4 retries after first failure)
+        retry=retry_if_exception_type(
+            (EtherscanRateLimitError, aiohttp.ClientError, asyncio.TimeoutError)
+        ),
+        before_sleep=before_sleep_log(logging.getLogger(__name__), logging.INFO),
+        reraise=True,  # Reraise the last exception if all retries fail
+    )
+    async def _get_token_transactions_page(
+        self, contract_address: str, address: str, start_block: int, page: int
+    ) -> list[dict]:
+        """
+        Fetch a single page of token transactions.
+
+        Args:
+            contract_address: The token contract address
+            address: The address to check transactions for
+            start_block: The block number to start checking from
+            page: Page number (1-based)
+
+        Returns:
+            List of transaction dictionaries for this page
+
+        Raises:
+            EtherscanRateLimitError: If the API rate limit is exceeded
+            EtherscanError: For other API errors
+        """
+        await self._ensure_session()
 
         params = {
             "chainid": "1",  # Ethereum mainnet - required for V2 API
@@ -361,6 +400,8 @@ class EtherscanClient:
             "contractaddress": contract_address,
             "startblock": start_block,
             "endblock": FAR_FUTURE_BLOCK,
+            "page": page,
+            "offset": self._TOKEN_TX_PAGE_SIZE,
             "sort": "asc",
             "apikey": self._api_key,
         }
@@ -390,6 +431,12 @@ class EtherscanClient:
                     # Explicitly check for rate limit messages in the response body
                     if "rate limit" in message.lower():
                         raise EtherscanRateLimitError(message)
+
+                    # "No transactions found" is a normal terminal condition when
+                    # paginating: the previous page was exactly full but there are
+                    # no more records. Treat it as an empty page so the loop stops.
+                    if message == "No transactions found":
+                        return []
 
                     # Handle common "NOTOK" cases with more context
                     error_details = f"API error: {message}"

--- a/uv.lock
+++ b/uv.lock
@@ -465,11 +465,11 @@ wheels = [
 
 [[package]]
 name = "pip"
-version = "26.0.1"
+version = "26.1.1"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/48/83/0d7d4e9efe3344b8e2fe25d93be44f64b65364d3c8d7bc6dc90198d5422e/pip-26.0.1.tar.gz", hash = "sha256:c4037d8a277c89b320abe636d59f91e6d0922d08a05b60e85e53b296613346d8", size = 1812747, upload-time = "2026-02-05T02:20:18.702Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/b6/48/cb9b7a682f6fe01a4221e1728941dd4ac3cd9090a17db3779d6ff490b602/pip-26.1.1.tar.gz", hash = "sha256:d36762751d156a4ee895de8af39aa0abeeeb577f93a2eca6ab62467bbf0f8a78", size = 1840400, upload-time = "2026-05-04T19:02:21.000Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/de/f0/c81e05b613866b76d2d1066490adf1a3dbc4ee9d9c839961c3fc8a6997af/pip-26.0.1-py3-none-any.whl", hash = "sha256:bdb1b08f4274833d62c1aa29e20907365a2ceb950410df15fc9521bad440122b", size = 1787723, upload-time = "2026-02-05T02:20:16.416Z" },
+    { url = "https://files.pythonhosted.org/packages/3a/eb/fea4d1d51c49832120f7f285d07306db3960f423a2612c6057caf3e8196f/pip-26.1.1-py3-none-any.whl", hash = "sha256:99cb1c2899893b075ff56e4ed0af55669a955b49ad7fb8d8603ecdaf4ed653fb", size = 1812777, upload-time = "2026-05-04T19:02:18.000Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

- Etherscan is reducing max records per request from 10,000 → **1,000** for free-tier users on **July 1, 2026** (affects `tokentx` and 10 other endpoints)
- Without this fix, the bot would silently truncate results at 1,000 records if an address has more new transactions than that between polling cycles
- Extracts per-page fetch into `_get_token_transactions_page` (private, `@retry`-decorated), and has `get_token_transactions` paginate through all pages automatically
- Handles the `"No transactions found"` status-0 response on page N+1 as a normal empty terminal page (not an error)

## Test plan

- [x] `test_get_token_transactions_single_page` — fewer than PAGE_SIZE records stops after one request
- [x] `test_get_token_transactions_paginates_multiple_pages` — full page triggers fetch of next page
- [x] `test_get_token_transactions_no_transactions_found_on_second_page` — status=0 "No transactions found" on page 2 treated as empty, pagination stops
- [x] `test_get_token_transactions_page_and_offset_params_sent` — verifies `page` and `offset` are in the request params
- [x] All 368 existing tests continue to pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Token transaction fetching now supports automatic pagination and treats empty/no-results responses as a clean end condition.

* **Tests**
  * Added pagination tests: single-page, multi-page continuation, termination on no-results, and correct paging parameters on subsequent requests.

* **Chores**
  * CI workflow schedule and triggers updated; dependency install step expanded and vulnerability scanning behavior adjusted.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/hostmaster/usdt_monitor_bot/pull/208)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->