### PR TITLE
fix(docker): reproducible builds via uv.lock and pinned base images

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -43,9 +43,11 @@ jobs:
       - name: Install dependencies
         # Upgrade pip to >=26.1 to address CVE-2026-3219 in the runner's
         # bundled pip (flagged by pip-audit below).
+        # Install from the locked uv.lock so pip-audit audits what ships in
+        # production, not a freshly-resolved set of transitive dependencies.
         run: |
           uv pip install --system --upgrade 'pip>=26.1'
-          uv pip install --system -e ".[security,test]"
+          uv pip install --system --frozen -r <(uv export --frozen --extra security --extra test)
       - name: Run Bandit
         run: |
           bandit --baseline baseline.json -r usdt_monitor_bot/

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -47,7 +47,8 @@ jobs:
         # production, not a freshly-resolved set of transitive dependencies.
         run: |
           uv pip install --system --upgrade 'pip>=26.1'
-          uv pip install --system --frozen -r <(uv export --frozen --extra security --extra test)
+          uv export --frozen --extra security --extra test -o /tmp/requirements.txt
+          uv pip install --system -r /tmp/requirements.txt
       - name: Run Bandit
         run: |
           bandit --baseline baseline.json -r usdt_monitor_bot/

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,21 +1,21 @@
-FROM python:3.14-alpine
+FROM python:3.14.3-alpine3.22
 
 ENV PYTHONDONTWRITEBYTECODE=1
 ENV PYTHONUNBUFFERED=1
 
-# Install uv
-COPY --from=ghcr.io/astral-sh/uv:latest /uv /usr/local/bin/uv
+# Install uv (pinned to minor version; Renovate will bump the digest)
+COPY --from=ghcr.io/astral-sh/uv:0.11 /uv /usr/local/bin/uv
 
 WORKDIR /app
 
-# Copy dependency files and source code for installation
-COPY pyproject.toml .
+# Copy lockfile + manifest so the install is fully reproducible
+COPY pyproject.toml uv.lock ./
 COPY usdt_monitor_bot/ usdt_monitor_bot/
-# Install dependencies directly from pyproject.toml
+# Install exact versions from uv.lock (--frozen aborts if lock is stale)
 # Using BuildKit cache mount to persist uv's cache between builds
 # This cache persists across builds in CI/CD, significantly speeding up dependency installation
 RUN --mount=type=cache,target=/root/.cache/uv \
-    uv pip install --system .
+    uv pip install --system --no-cache -r <(uv export --frozen --no-dev)
 
 WORKDIR /app
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -15,7 +15,8 @@ COPY usdt_monitor_bot/ usdt_monitor_bot/
 # Using BuildKit cache mount to persist uv's cache between builds
 # This cache persists across builds in CI/CD, significantly speeding up dependency installation
 RUN --mount=type=cache,target=/root/.cache/uv \
-    uv pip install --system --no-cache -r <(uv export --frozen --no-dev)
+    uv export --frozen --no-dev -o /tmp/requirements.txt && \
+    uv pip install --system --no-cache -r /tmp/requirements.txt
 
 WORKDIR /app
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -16,7 +16,8 @@ COPY usdt_monitor_bot/ usdt_monitor_bot/
 # This cache persists across builds in CI/CD, significantly speeding up dependency installation
 RUN --mount=type=cache,target=/root/.cache/uv \
     uv export --frozen --no-dev -o /tmp/requirements.txt && \
-    uv pip install --system --no-cache -r /tmp/requirements.txt
+    uv pip install --system --no-cache -r /tmp/requirements.txt && \
+    uv pip install --system --no-cache --no-deps .
 
 WORKDIR /app
 


### PR DESCRIPTION
## Summary

Make Docker builds reproducible by installing from the locked `uv.lock` instead of re-resolving transitive dependencies.

**Problem:** `uv pip install --system .` (without `uv.lock`) silently picks whatever transitive versions resolve at build time. `uv.lock` already pins `aiohttp==3.13.5` (fixing 18 CVEs vs 3.13.2), but built images have been shipping the vulnerable version.

**Changes:**
- Copy `uv.lock` into the build context and use `--frozen` install
- Pin `ghcr.io/astral-sh/uv` from `:latest` to `:0.11`
- Pin Python base image from `python:3.14-alpine` to `python:3.14.3-alpine3.22`
- Update `security.yml` to audit the locked env (what ships) rather than a fresh resolution

## Test plan
- [ ] `ruff check` passes
- [ ] CI docker build passes
- [ ] `pip-audit` in CI now reports the locked `aiohttp` version, not a re-resolved one