### PR TITLE
perf: parallel address processing + thread-safe rate limiter

### DIFF
--- a/tests/test_etherscan.py
+++ b/tests/test_etherscan.py
@@ -482,52 +482,52 @@ async def test_client_session_cleanup(mock_config, mock_aiohttp_session, monkeyp
 # --- AdaptiveRateLimiter ---
 
 
-def test_rate_limiter_on_rate_limit_increases_delay():
+async def test_rate_limiter_on_rate_limit_increases_delay():
     limiter = AdaptiveRateLimiter(initial_delay=1.0, max_delay=10.0, backoff_factor=2.0)
-    limiter.on_rate_limit()
+    await limiter.on_rate_limit()
     assert limiter.current_delay == 2.0
 
 
-def test_rate_limiter_on_rate_limit_caps_at_max():
+async def test_rate_limiter_on_rate_limit_caps_at_max():
     limiter = AdaptiveRateLimiter(initial_delay=8.0, max_delay=10.0, backoff_factor=2.0)
-    limiter.on_rate_limit()
+    await limiter.on_rate_limit()
     assert limiter.current_delay == 10.0
 
 
-def test_rate_limiter_on_rate_limit_resets_consecutive_successes():
+async def test_rate_limiter_on_rate_limit_resets_consecutive_successes():
     """on_rate_limit always resets the consecutive-success counter to zero."""
     # Use a very long cooldown so on_success never reduces delay (counter won't auto-reset)
     limiter = AdaptiveRateLimiter(
         initial_delay=1.0, success_threshold=5, recovery_cooldown=9999.0
     )
-    limiter.on_rate_limit()  # Set _last_rate_limit_time to now
+    await limiter.on_rate_limit()  # Set _last_rate_limit_time to now
     for _ in range(3):
-        limiter.on_success()
+        await limiter.on_success()
     assert limiter._consecutive_successes == 3
-    limiter.on_rate_limit()
+    await limiter.on_rate_limit()
     assert limiter._consecutive_successes == 0
 
 
-def test_rate_limiter_on_success_increments_counter():
+async def test_rate_limiter_on_success_increments_counter():
     limiter = AdaptiveRateLimiter(initial_delay=1.0)
-    limiter.on_success()
+    await limiter.on_success()
     assert limiter._consecutive_successes == 1
-    limiter.on_success()
+    await limiter.on_success()
     assert limiter._consecutive_successes == 2
 
 
-def test_rate_limiter_on_success_does_not_reduce_below_threshold():
+async def test_rate_limiter_on_success_does_not_reduce_below_threshold():
     """Delay should NOT reduce before success_threshold is reached."""
     limiter = AdaptiveRateLimiter(
         initial_delay=1.0, min_delay=0.1, success_threshold=10, recovery_cooldown=0.0
     )
     initial = limiter.current_delay
     for _ in range(9):  # One less than threshold
-        limiter.on_success()
+        await limiter.on_success()
     assert limiter.current_delay == initial
 
 
-def test_rate_limiter_on_success_reduces_delay_after_threshold_and_cooldown():
+async def test_rate_limiter_on_success_reduces_delay_after_threshold_and_cooldown():
     """Delay reduces after threshold successes with no cooldown restriction."""
     limiter = AdaptiveRateLimiter(
         initial_delay=2.0, min_delay=0.1, recovery_factor=0.5,
@@ -535,31 +535,31 @@ def test_rate_limiter_on_success_reduces_delay_after_threshold_and_cooldown():
     )
     # Ensure _last_rate_limit_time is in the past (it starts at 0.0)
     for _ in range(3):
-        limiter.on_success()
+        await limiter.on_success()
     assert limiter.current_delay < 2.0
 
 
-def test_rate_limiter_does_not_reduce_during_cooldown():
+async def test_rate_limiter_does_not_reduce_during_cooldown():
     """Delay should NOT reduce if still within cooldown window after rate limit."""
     limiter = AdaptiveRateLimiter(
         initial_delay=2.0, min_delay=0.1, recovery_factor=0.5,
         success_threshold=3, recovery_cooldown=9999.0,  # Very long cooldown
     )
-    limiter.on_rate_limit()  # Records _last_rate_limit_time = now
+    await limiter.on_rate_limit()  # Records _last_rate_limit_time = now
     initial_after_backoff = limiter.current_delay
     for _ in range(5):
-        limiter.on_success()
+        await limiter.on_success()
     assert limiter.current_delay == initial_after_backoff
 
 
-def test_rate_limiter_does_not_reduce_below_min_delay():
+async def test_rate_limiter_does_not_reduce_below_min_delay():
     """Delay must never drop below min_delay."""
     limiter = AdaptiveRateLimiter(
         initial_delay=0.11, min_delay=0.1, recovery_factor=0.5,
         success_threshold=3, recovery_cooldown=0.0,
     )
     for _ in range(20):
-        limiter.on_success()
+        await limiter.on_success()
     assert limiter.current_delay >= 0.1
 
 

--- a/usdt_monitor_bot/checker.py
+++ b/usdt_monitor_bot/checker.py
@@ -723,110 +723,131 @@ class TransactionChecker:
     async def _process_single_address(
         self,
         address_lower: str,
-        stats: dict,
-        update_tasks: list,
         latest_block: int | None,
-    ) -> None:
+        semaphore: asyncio.Semaphore,
+    ) -> tuple[dict, list]:
         """
-        Process a single address: fetch, analyze, and update block number.
+        Process a single address: fetch, analyze, and determine block update.
+
+        Runs under the provided semaphore to bound concurrent address fetches.
+        Returns a (stats_delta, update_tasks) tuple so the caller can merge
+        results from concurrent executions without shared mutable state.
 
         Args:
             address_lower: The address to process (lowercase)
-            stats: Dictionary to update with statistics
-            update_tasks: List to append block update tasks
             latest_block: Latest chain block for the current cycle (shared
                 across all addresses in one cycle), or None if unavailable.
+            semaphore: Bounds the number of addresses processed concurrently.
+
+        Returns:
+            Tuple of (local_stats, local_update_tasks) where local_stats is a
+            dict with the same keys as the cycle-level stats dict and
+            local_update_tasks is a list of DB coroutines to run after all
+            addresses have been processed.
         """
-        try:
-            start_block = await self._db.get_last_checked_block(address_lower)
+        local_stats = {
+            "total_transactions_found": 0,
+            "total_transactions_processed": 0,
+            "addresses_with_transactions": 0,
+            "addresses_updated": 0,
+            "errors_count": 0,
+            "warnings_count": 0,
+        }
+        local_update_tasks: list = []
 
-            logging.debug(f"Check {address_lower[:8]}... from block {start_block + 1}")
+        async with semaphore:
+            try:
+                start_block = await self._db.get_last_checked_block(address_lower)
 
-            if latest_block is None:
-                logging.debug(
-                    f"No latest block for {address_lower[:8]}..., proceeding without cap"
-                )
+                logging.debug(f"Check {address_lower[:8]}... from block {start_block + 1}")
 
-            raw_transactions, all_tokens_ok = await self._fetch_transactions_for_address(
-                address_lower, start_block + 1
-            )
-
-            stats["total_transactions_found"] += len(raw_transactions)
-            if raw_transactions:
-                stats["addresses_with_transactions"] += 1
-
-            result = await self._process_address_transactions(
-                address_lower, raw_transactions, start_block, latest_block
-            )
-            new_last_block = result.new_last_block
-            processed_count = result.processed_count
-            max_block_in_processed_batch = result.max_block_in_processed_batch
-            stats["total_transactions_processed"] += processed_count
-
-            # If any per-token fetch failed, do NOT advance the block checkpoint.
-            # Advancing would permanently skip the failing token's transactions
-            # in the queried block range on subsequent cycles. Persist processed
-            # txs (already stored by _process_address_transactions) and retry
-            # the same block range next cycle.
-            if not all_tokens_ok:
-                logging.warning(
-                    f"Partial fetch for {address_lower[:8]}...: at least one token "
-                    f"errored; not advancing block checkpoint (will retry next cycle)"
-                )
-                stats["warnings_count"] += 1
-                return
-
-            # Determine next block and update if needed
-            block_result = await self._block_tracker.determine_next_block(
-                start_block,
-                new_last_block,
-                raw_transactions,
-                address_lower,
-                latest_block,
-            )
-
-            if self._should_update_block(start_block, block_result):
                 if latest_block is None:
+                    logging.debug(
+                        f"No latest block for {address_lower[:8]}..., proceeding without cap"
+                    )
+
+                raw_transactions, all_tokens_ok = await self._fetch_transactions_for_address(
+                    address_lower, start_block + 1
+                )
+
+                local_stats["total_transactions_found"] += len(raw_transactions)
+                if raw_transactions:
+                    local_stats["addresses_with_transactions"] += 1
+
+                result = await self._process_address_transactions(
+                    address_lower, raw_transactions, start_block, latest_block
+                )
+                new_last_block = result.new_last_block
+                processed_count = result.processed_count
+                max_block_in_processed_batch = result.max_block_in_processed_batch
+                local_stats["total_transactions_processed"] += processed_count
+
+                # If any per-token fetch failed, do NOT advance the block checkpoint.
+                # Advancing would permanently skip the failing token's transactions
+                # in the queried block range on subsequent cycles. Persist processed
+                # txs (already stored by _process_address_transactions) and retry
+                # the same block range next cycle.
+                if not all_tokens_ok:
                     logging.warning(
-                        f"Defensive block cap skipped for {address_lower[:8]}...: "
-                        f"could not fetch latest block, persisting uncapped {block_result.final_block_number}"
+                        f"Partial fetch for {address_lower[:8]}...: at least one token "
+                        f"errored; not advancing block checkpoint (will retry next cycle)"
                     )
-                final_block_to_update = self._block_tracker.cap_block_to_latest(
-                    block_result.final_block_number,
-                    latest_block,
+                    local_stats["warnings_count"] += 1
+                    return local_stats, local_update_tasks
+
+                # Determine next block and update if needed
+                block_result = await self._block_tracker.determine_next_block(
+                    start_block,
+                    new_last_block,
+                    raw_transactions,
                     address_lower,
-                    context="defensive check before database update",
-                    log_level="warning",
+                    latest_block,
                 )
-                # Never persist a block lower than the highest we already processed, or we will
-                # re-fetch and re-notify the same transactions next cycle (e.g. when API returns
-                # txs in blocks ahead of reported "latest" block)
-                if max_block_in_processed_batch > 0:
-                    final_block_to_update = max(
-                        final_block_to_update, max_block_in_processed_batch
-                    )
 
-                self._log_block_update(
-                    address_lower, start_block, block_result, final_block_to_update
-                )
-                update_tasks.append(
-                    self._db.update_last_checked_block(
-                        address_lower, final_block_to_update
+                if self._should_update_block(start_block, block_result):
+                    if latest_block is None:
+                        logging.warning(
+                            f"Defensive block cap skipped for {address_lower[:8]}...: "
+                            f"could not fetch latest block, persisting uncapped {block_result.final_block_number}"
+                        )
+                    final_block_to_update = self._block_tracker.cap_block_to_latest(
+                        block_result.final_block_number,
+                        latest_block,
+                        address_lower,
+                        context="defensive check before database update",
+                        log_level="warning",
                     )
-                )
-                stats["addresses_updated"] += 1
+                    # Never persist a block lower than the highest we already processed, or we will
+                    # re-fetch and re-notify the same transactions next cycle (e.g. when API returns
+                    # txs in blocks ahead of reported "latest" block)
+                    if max_block_in_processed_batch > 0:
+                        final_block_to_update = max(
+                            final_block_to_update, max_block_in_processed_batch
+                        )
 
-        except EtherscanRateLimitError:
-            logging.warning(f"Rate limit: {address_lower[:8]}..., skip cycle")
-            stats["warnings_count"] += 1
-        except (TimeoutError, aiohttp.ClientError) as e:
-            logging.error(f"Network error {address_lower[:8]}...: {e}")
-            stats["errors_count"] += 1
-        except Exception as e:
-            logging.error(
-                f"Error processing {address_lower[:8]}...: {e}", exc_info=True
-            )
-            stats["errors_count"] += 1
+                    self._log_block_update(
+                        address_lower, start_block, block_result, final_block_to_update
+                    )
+                    local_update_tasks.append(
+                        self._db.update_last_checked_block(
+                            address_lower, final_block_to_update
+                        )
+                    )
+                    local_stats["addresses_updated"] += 1
+
+            except EtherscanRateLimitError:
+                logging.warning(f"Rate limit: {address_lower[:8]}..., skip cycle")
+                local_stats["warnings_count"] += 1
+            except (TimeoutError, aiohttp.ClientError) as e:
+                logging.error(f"Network error {address_lower[:8]}...: {e}")
+                local_stats["errors_count"] += 1
+            except Exception as e:
+                logging.error(
+                    f"Error processing {address_lower[:8]}...: {e}", exc_info=True
+                )
+                local_stats["errors_count"] += 1
+
+        return local_stats, local_update_tasks
 
     async def check_all_addresses(self) -> None:
         """
@@ -853,8 +874,6 @@ class TransactionChecker:
             "errors_count": 0,
             "warnings_count": 0,
         }
-        update_tasks = []
-
         # Fetch latest_block once per cycle and reuse for every address.
         # This saves N-1 API calls per cycle (N = number of monitored addresses)
         # since the latest chain block is the same for all of them.
@@ -862,10 +881,25 @@ class TransactionChecker:
         if latest_block is None:
             logging.debug("No latest block for this cycle, proceeding without cap")
 
-        for address in addresses_to_check:
-            await self._process_single_address(
-                address.lower(), stats, update_tasks, latest_block
-            )
+        semaphore = asyncio.Semaphore(8)  # bound concurrent address fetches
+        results = await asyncio.gather(
+            *[
+                self._process_single_address(addr.lower(), latest_block, semaphore)
+                for addr in addresses_to_check
+            ],
+            return_exceptions=True,
+        )
+
+        update_tasks = []
+        for result in results:
+            if isinstance(result, Exception):
+                logging.warning(f"Address processing error: {result}")
+                stats["errors_count"] += 1
+                continue
+            local_stats, local_tasks = result
+            for key, value in local_stats.items():
+                stats[key] += value
+            update_tasks.extend(local_tasks)
 
         if update_tasks:
             logging.debug(f"Updating blocks for {len(update_tasks)} addresses")

--- a/usdt_monitor_bot/checker.py
+++ b/usdt_monitor_bot/checker.py
@@ -38,6 +38,15 @@ from usdt_monitor_bot.transaction_parser import (
     format_transaction_log,
 )
 
+_STATS_KEYS = (
+    "total_transactions_found",
+    "total_transactions_processed",
+    "addresses_with_transactions",
+    "addresses_updated",
+    "errors_count",
+    "warnings_count",
+)
+
 
 @dataclass
 class AddressProcessingResult:
@@ -745,14 +754,7 @@ class TransactionChecker:
             local_update_tasks is a list of DB coroutines to run after all
             addresses have been processed.
         """
-        local_stats = {
-            "total_transactions_found": 0,
-            "total_transactions_processed": 0,
-            "addresses_with_transactions": 0,
-            "addresses_updated": 0,
-            "errors_count": 0,
-            "warnings_count": 0,
-        }
+        local_stats = {k: 0 for k in _STATS_KEYS}
         local_update_tasks: list = []
 
         async with semaphore:
@@ -866,14 +868,7 @@ class TransactionChecker:
 
         logging.debug(f"Checking {len(addresses_to_check)} addresses")
 
-        stats = {
-            "total_transactions_found": 0,
-            "total_transactions_processed": 0,
-            "addresses_with_transactions": 0,
-            "addresses_updated": 0,
-            "errors_count": 0,
-            "warnings_count": 0,
-        }
+        stats = {k: 0 for k in _STATS_KEYS}
         # Fetch latest_block once per cycle and reuse for every address.
         # This saves N-1 API calls per cycle (N = number of monitored addresses)
         # since the latest chain block is the same for all of them.
@@ -892,7 +887,7 @@ class TransactionChecker:
 
         update_tasks = []
         for result in results:
-            if isinstance(result, Exception):
+            if isinstance(result, BaseException):
                 logging.warning(f"Address processing error: {result}")
                 stats["errors_count"] += 1
                 continue

--- a/usdt_monitor_bot/etherscan.py
+++ b/usdt_monitor_bot/etherscan.py
@@ -79,40 +79,43 @@ class AdaptiveRateLimiter:
         self._recovery_cooldown = recovery_cooldown
         self._consecutive_successes = 0
         self._last_rate_limit_time = 0.0
+        self._lock = asyncio.Lock()
 
     async def wait(self) -> None:
         """Wait for the current delay period before making a request."""
         await asyncio.sleep(self._current_delay)
 
-    def on_rate_limit(self) -> None:
+    async def on_rate_limit(self) -> None:
         """Called when a rate limit error is encountered. Increases delay."""
-        self._current_delay = min(
-            self._current_delay * self._backoff_factor, self._max_delay
-        )
-        self._consecutive_successes = 0
-        self._last_rate_limit_time = time.monotonic()
-        logging.info(f"Rate limit hit, delay={self._current_delay:.2f}s")
-
-    def on_success(self) -> None:
-        """Called when a request succeeds. Gradually reduces delay if stable."""
-        self._consecutive_successes += 1
-
-        # Only reduce delay after a threshold of consecutive successes
-        # and if enough time has passed since last rate limit
-        time_since_rate_limit = time.monotonic() - self._last_rate_limit_time
-        if (
-            self._consecutive_successes >= self._success_threshold
-            and time_since_rate_limit > self._recovery_cooldown
-        ):
-            new_delay = max(
-                self._current_delay * self._recovery_factor, self._min_delay
+        async with self._lock:
+            self._current_delay = min(
+                self._current_delay * self._backoff_factor, self._max_delay
             )
-            if new_delay < self._current_delay:
-                logging.debug(
-                    f"Delay reduced: {self._current_delay:.2f}s->{new_delay:.2f}s"
+            self._consecutive_successes = 0
+            self._last_rate_limit_time = time.monotonic()
+            logging.info(f"Rate limit hit, delay={self._current_delay:.2f}s")
+
+    async def on_success(self) -> None:
+        """Called when a request succeeds. Gradually reduces delay if stable."""
+        async with self._lock:
+            self._consecutive_successes += 1
+
+            # Only reduce delay after a threshold of consecutive successes
+            # and if enough time has passed since last rate limit
+            time_since_rate_limit = time.monotonic() - self._last_rate_limit_time
+            if (
+                self._consecutive_successes >= self._success_threshold
+                and time_since_rate_limit > self._recovery_cooldown
+            ):
+                new_delay = max(
+                    self._current_delay * self._recovery_factor, self._min_delay
                 )
-                self._current_delay = new_delay
-                self._consecutive_successes = 0
+                if new_delay < self._current_delay:
+                    logging.debug(
+                        f"Delay reduced: {self._current_delay:.2f}s->{new_delay:.2f}s"
+                    )
+                    self._current_delay = new_delay
+                    self._consecutive_successes = 0
 
     @property
     def current_delay(self) -> float:
@@ -311,11 +314,11 @@ class EtherscanClient:
         try:
             result = await request_func()
             # Mark success - rate limiter will gradually reduce delay
-            self._rate_limiter.on_success()
+            await self._rate_limiter.on_success()
             return result
         except EtherscanRateLimitError:
             # Adapt rate limiter when rate limit error is encountered
-            self._rate_limiter.on_rate_limit()
+            await self._rate_limiter.on_rate_limit()
             raise
 
     # Etherscan free tier caps at 1,000 records per request (effective July 1, 2026,


### PR DESCRIPTION
## Summary

Two related changes that must ship together:

**1. Thread-safe AdaptiveRateLimiter** — `etherscan.py`
- `on_rate_limit()` and `on_success()` now hold an `asyncio.Lock` while mutating shared state.
- Required before safe concurrent use.

**2. Parallel per-address processing** — `checker.py`
- Replaces serial `for address in addresses: await _process_single_address(...)` with `asyncio.gather` bounded by `asyncio.Semaphore(8)`.
- `_process_single_address` now returns `(stats_delta, update_tasks)` instead of mutating shared state, allowing safe concurrent execution.
- Cycle wall-time now scales with `max(per-address latency)` instead of `sum(per-address latency)`.

## Test plan
- [ ] `ruff check` passes
- [ ] `pytest` passes
- [ ] Manual: confirm cycle completes in ~constant time regardless of address count (up to semaphore bound)