### PR TITLE
feat: per-user command rate limiting via aiogram middleware

### DIFF
--- a/tests/test_middleware.py
+++ b/tests/test_middleware.py
@@ -14,14 +14,19 @@ from usdt_monitor_bot.middleware import UserRateLimitMiddleware
 # ---------------------------------------------------------------------------
 
 
-def _make_message(user_id: int = 1) -> AsyncMock:
-    """Return a minimal AsyncMock that looks like an aiogram Message."""
+def _make_message(user_id: int = 1, text: str = "/start") -> AsyncMock:
+    """Return a minimal AsyncMock that looks like an aiogram Message.
+
+    Defaults to a command text ("/start") so tests exercise the rate-limit path.
+    Pass text="" or text="hello" to simulate a non-command message.
+    """
     user = MagicMock(spec=User)
     user.id = user_id
 
     msg = AsyncMock(spec=Message)
     msg.from_user = user
     msg.answer = AsyncMock()
+    msg.text = text
     return msg
 
 
@@ -136,7 +141,49 @@ async def test_message_without_from_user_passes_through():
 
     msg = AsyncMock(spec=Message)
     msg.from_user = None
+    msg.text = "/start"  # command text, so the from_user=None path is exercised
 
     result = await mw(handler, msg, {})
     assert result == "ok"
     handler.assert_awaited_once()
+
+
+async def test_non_command_message_passes_through_without_counting():
+    """Plain text messages (no '/' prefix) bypass rate limiting entirely and are not counted."""
+    mw = UserRateLimitMiddleware(max_calls=2, window_seconds=60.0)
+    msg_text = _make_message(user_id=10, text="hello world")
+    handler = AsyncMock(return_value="ok")
+
+    # Send many non-command messages — none should be rate-limited or counted
+    for _ in range(5):
+        result = await mw(handler, msg_text, {})
+        assert result == "ok"
+
+    assert handler.await_count == 5
+    msg_text.answer.assert_not_called()
+    # Non-command messages must not create tracking entries
+    assert 10 not in mw._user_timestamps
+
+
+async def test_expired_timestamps_cleaned_up_from_user_timestamps():
+    """After the window expires, the user's key is removed from _user_timestamps."""
+    mw = UserRateLimitMiddleware(max_calls=3, window_seconds=1.0)
+    msg = _make_message(user_id=20)
+    handler = AsyncMock(side_effect=_noop_handler)
+
+    # Exhaust the quota within the window
+    for _ in range(3):
+        await mw(handler, msg, {})
+
+    assert 20 in mw._user_timestamps
+    assert len(mw._user_timestamps[20]) == 3
+
+    # Advance time past the window; the next call should evict all entries and clean up the key
+    future = time.monotonic() + 2.0
+    with patch("usdt_monitor_bot.middleware.time.monotonic", return_value=future):
+        result = await mw(handler, msg, {})
+
+    assert result == "handled"
+    # Key must exist (re-created for the new call's timestamp), but hold exactly one entry
+    assert 20 in mw._user_timestamps
+    assert len(mw._user_timestamps[20]) == 1

--- a/tests/test_middleware.py
+++ b/tests/test_middleware.py
@@ -1,0 +1,142 @@
+# tests/test_middleware.py
+"""Tests for UserRateLimitMiddleware."""
+
+import time
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock, patch
+
+from aiogram.types import Message, User
+
+from usdt_monitor_bot.middleware import UserRateLimitMiddleware
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_message(user_id: int = 1) -> AsyncMock:
+    """Return a minimal AsyncMock that looks like an aiogram Message."""
+    user = MagicMock(spec=User)
+    user.id = user_id
+
+    msg = AsyncMock(spec=Message)
+    msg.from_user = user
+    msg.answer = AsyncMock()
+    return msg
+
+
+async def _noop_handler(event: Any, data: dict) -> str:
+    """Sentinel handler so we can assert it was (not) called."""
+    return "handled"
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+async def test_first_calls_pass_through():
+    """Calls within the limit should reach the handler."""
+    mw = UserRateLimitMiddleware(max_calls=3, window_seconds=60.0)
+    msg = _make_message(user_id=42)
+    handler = AsyncMock(side_effect=_noop_handler, return_value="handled")
+
+    for _ in range(3):
+        result = await mw(handler, msg, {})
+        assert result == "handled"
+
+    assert handler.await_count == 3
+    msg.answer.assert_not_called()
+
+
+async def test_exceeding_limit_drops_update():
+    """The (max_calls+1)-th call within the window must be dropped."""
+    mw = UserRateLimitMiddleware(max_calls=3, window_seconds=60.0)
+    msg = _make_message(user_id=99)
+    handler = AsyncMock(side_effect=_noop_handler)
+
+    # Exhaust the quota
+    for _ in range(3):
+        await mw(handler, msg, {})
+
+    # This one should be rate-limited
+    result = await mw(handler, msg, {})
+
+    assert result is None  # dropped — middleware returns None
+    assert handler.await_count == 3  # handler NOT called a 4th time
+    msg.answer.assert_awaited_once()
+    reply_text: str = msg.answer.call_args[0][0]
+    assert "Too many requests" in reply_text
+
+
+async def test_window_expiry_resets_quota():
+    """After the window has passed, the quota resets and calls go through again."""
+    mw = UserRateLimitMiddleware(max_calls=2, window_seconds=1.0)
+    msg = _make_message(user_id=7)
+    handler = AsyncMock(side_effect=_noop_handler)
+
+    # Exhaust quota
+    await mw(handler, msg, {})
+    await mw(handler, msg, {})
+    assert handler.await_count == 2
+
+    # Simulate time advancing past the window
+    future = time.monotonic() + 1.5
+    with patch("usdt_monitor_bot.middleware.time.monotonic", return_value=future):
+        result = await mw(handler, msg, {})
+
+    assert result == "handled"
+    assert handler.await_count == 3
+    msg.answer.assert_not_called()
+
+
+async def test_different_users_independent_quotas():
+    """Rate limits are tracked per user_id — one user's quota doesn't affect another."""
+    mw = UserRateLimitMiddleware(max_calls=2, window_seconds=60.0)
+    handler = AsyncMock(side_effect=_noop_handler)
+
+    user_a = _make_message(user_id=1)
+    user_b = _make_message(user_id=2)
+
+    # Exhaust user_a's quota
+    await mw(handler, user_a, {})
+    await mw(handler, user_a, {})
+    await mw(handler, user_a, {})  # dropped
+
+    assert handler.await_count == 2
+    user_a.answer.assert_awaited_once()
+
+    # user_b should still be allowed
+    result = await mw(handler, user_b, {})
+    assert result == "handled"
+    user_b.answer.assert_not_called()
+
+
+async def test_non_message_events_pass_through():
+    """Non-Message TelegramObjects are forwarded without rate-limit checks."""
+    from aiogram.types import TelegramObject
+
+    mw = UserRateLimitMiddleware(max_calls=1, window_seconds=60.0)
+    handler = AsyncMock(return_value="ok")
+
+    # Use a plain TelegramObject (not a Message)
+    non_msg = MagicMock(spec=TelegramObject)
+    # Ensure it is NOT an instance of Message
+    assert not isinstance(non_msg, Message)
+
+    result = await mw(handler, non_msg, {})
+    assert result == "ok"
+    handler.assert_awaited_once()
+
+
+async def test_message_without_from_user_passes_through():
+    """Messages with no from_user (channel posts) bypass rate limiting."""
+    mw = UserRateLimitMiddleware(max_calls=1, window_seconds=60.0)
+    handler = AsyncMock(return_value="ok")
+
+    msg = AsyncMock(spec=Message)
+    msg.from_user = None
+
+    result = await mw(handler, msg, {})
+    assert result == "ok"
+    handler.assert_awaited_once()

--- a/usdt_monitor_bot/config.py
+++ b/usdt_monitor_bot/config.py
@@ -67,6 +67,8 @@ class BotConfig:
         moralis_api_key: str | None = None,
         fallback_failure_threshold: int = 3,
         fallback_cooldown_seconds: float = 300.0,
+        rate_limit_max_calls: int = 10,
+        rate_limit_window_seconds: float = 60.0,
     ):
         # Telegram Bot Token
         self.telegram_bot_token = telegram_bot_token
@@ -123,6 +125,10 @@ class BotConfig:
         self.moralis_api_key = moralis_api_key
         self.fallback_failure_threshold = fallback_failure_threshold
         self.fallback_cooldown_seconds = fallback_cooldown_seconds
+
+        # Per-user Telegram command rate limiting
+        self.rate_limit_max_calls = rate_limit_max_calls
+        self.rate_limit_window_seconds = rate_limit_window_seconds
 
         # Initialize token registry
         self.token_registry = TokenRegistry()
@@ -260,6 +266,10 @@ def load_config() -> BotConfig:
     fallback_failure_threshold = _get_env_int("FALLBACK_FAILURE_THRESHOLD", 3)
     fallback_cooldown_seconds = _get_env_float("FALLBACK_COOLDOWN_SECONDS", 300.0)
 
+    # Per-user Telegram command rate limiting
+    rate_limit_max_calls = _get_env_int("RATE_LIMIT_MAX_CALLS", 10)
+    rate_limit_window_seconds = _get_env_float("RATE_LIMIT_WINDOW_SECONDS", 60.0)
+
     # Spam detection debugging option
     spam_debug_env = os.getenv("SPAM_DETECTION_DEBUG", "").lower()
     spam_detection_debug = spam_debug_env in ("true", "1", "yes", "on")
@@ -334,6 +344,8 @@ def load_config() -> BotConfig:
         moralis_api_key=moralis_api_key,
         fallback_failure_threshold=fallback_failure_threshold,
         fallback_cooldown_seconds=fallback_cooldown_seconds,
+        rate_limit_max_calls=rate_limit_max_calls,
+        rate_limit_window_seconds=rate_limit_window_seconds,
     )
 
     # Token configuration overrides

--- a/usdt_monitor_bot/main.py
+++ b/usdt_monitor_bot/main.py
@@ -27,6 +27,7 @@ from usdt_monitor_bot.config import load_config
 from usdt_monitor_bot.database import DatabaseManager
 from usdt_monitor_bot.etherscan import EtherscanClient
 from usdt_monitor_bot.handlers import register_handlers
+from usdt_monitor_bot.middleware import UserRateLimitMiddleware
 from usdt_monitor_bot.moralis import MoralisClient
 from usdt_monitor_bot.notifier import NotificationService
 from usdt_monitor_bot.spam_detector import SpamDetector, enable_spam_detector_debugging
@@ -94,7 +95,16 @@ async def main() -> None:
         session=bot_session,
     )
     dp = Dispatcher(db_manager=db_manager)
-    logging.debug(f"Bot initialized with session limit={config.bot_session_connection_limit}")
+    dp.message.middleware(
+        UserRateLimitMiddleware(
+            max_calls=config.rate_limit_max_calls,
+            window_seconds=config.rate_limit_window_seconds,
+        )
+    )
+    logging.debug(
+        f"Bot initialized with session limit={config.bot_session_connection_limit}, "
+        f"rate_limit={config.rate_limit_max_calls} calls/{config.rate_limit_window_seconds}s"
+    )
 
     # 8. Initialize Services
     etherscan_client = EtherscanClient(config=config)

--- a/usdt_monitor_bot/middleware.py
+++ b/usdt_monitor_bot/middleware.py
@@ -32,7 +32,7 @@ class UserRateLimitMiddleware(BaseMiddleware):
         event: TelegramObject,
         data: dict[str, Any],
     ) -> Any:
-        if not isinstance(event, Message):
+        if not isinstance(event, Message) or not (event.text and event.text.startswith("/")):
             return await handler(event, data)
 
         user_id = event.from_user.id if event.from_user else None
@@ -45,6 +45,11 @@ class UserRateLimitMiddleware(BaseMiddleware):
         # Evict timestamps that have fallen outside the window
         while timestamps and now - timestamps[0] > self._window:
             timestamps.popleft()
+
+        # If the deque is now empty, clean up the key and let the call through
+        if not timestamps:
+            del self._user_timestamps[user_id]
+            timestamps = self._user_timestamps[user_id]  # fresh deque via defaultdict
 
         if len(timestamps) >= self._max_calls:
             await event.answer(

--- a/usdt_monitor_bot/middleware.py
+++ b/usdt_monitor_bot/middleware.py
@@ -1,0 +1,56 @@
+"""
+Rate-limiting middleware for the Telegram bot.
+
+Provides a sliding-window per-user command throttle to prevent a single
+user from exhausting SQLite write capacity or Etherscan API quota.
+"""
+
+import time
+from collections import defaultdict, deque
+from collections.abc import Awaitable, Callable
+from typing import Any
+
+from aiogram import BaseMiddleware
+from aiogram.types import Message, TelegramObject
+
+
+class UserRateLimitMiddleware(BaseMiddleware):
+    """Limit each user to max_calls per window_seconds across all commands.
+
+    Uses a sliding-window (deque of monotonic timestamps) per user_id.
+    State is in-memory and resets on restart — acceptable for a single-process bot.
+    """
+
+    def __init__(self, max_calls: int = 10, window_seconds: float = 60.0) -> None:
+        self._max_calls = max_calls
+        self._window = window_seconds
+        self._user_timestamps: dict[int, deque[float]] = defaultdict(deque)
+
+    async def __call__(
+        self,
+        handler: Callable[[TelegramObject, dict[str, Any]], Awaitable[Any]],
+        event: TelegramObject,
+        data: dict[str, Any],
+    ) -> Any:
+        if not isinstance(event, Message):
+            return await handler(event, data)
+
+        user_id = event.from_user.id if event.from_user else None
+        if user_id is None:
+            return await handler(event, data)
+
+        now = time.monotonic()
+        timestamps = self._user_timestamps[user_id]
+
+        # Evict timestamps that have fallen outside the window
+        while timestamps and now - timestamps[0] > self._window:
+            timestamps.popleft()
+
+        if len(timestamps) >= self._max_calls:
+            await event.answer(
+                "Too many requests. Please wait a moment before using commands again."
+            )
+            return None  # drop the update — handler is never called
+
+        timestamps.append(now)
+        return await handler(event, data)


### PR DESCRIPTION
## Summary

Add per-user command rate limiting via aiogram middleware to prevent command spam.

**Problem:** Any Telegram user could spam `/add`/`/remove`/`/list`/`/spam` without limit, exhausting SQLite write capacity and Etherscan API quota.

**Changes:**
- New `UserRateLimitMiddleware` in `usdt_monitor_bot/middleware.py`: in-memory sliding-window counter per `user_id`, 10 commands / 60 s by default
- Registered on `dp.message` in `main.py` before handler routing
- Throttled users receive a friendly error reply; the update is dropped
- Configurable via `RATE_LIMIT_MAX_CALLS` / `RATE_LIMIT_WINDOW_SECONDS` env vars

## Test plan
- [ ] `ruff check` passes
- [ ] `pytest` passes (new `test_middleware.py`)
- [ ] Manual: spam `/list` 11x rapidly → 11th gets rate-limit reply