### PR TITLE
feat: replace in-memory notification dedup cache with persistent DB table

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -130,6 +130,8 @@ def mock_db_manager() -> AsyncMock:
     # Defaults for batch spam-enrichment paths (avoid unawaited AsyncMock coroutines).
     db.get_recent_transactions.return_value = []
     db.get_known_senders.return_value = set()
+    # Default: every notification is treated as new (not a duplicate).
+    db.mark_notification_sent.return_value = True
     return db
 
 

--- a/tests/test_checker.py
+++ b/tests/test_checker.py
@@ -961,6 +961,37 @@ async def test_notification_dedup_allows_send_when_new(
     mock_notifier.send_token_notification.assert_awaited_once()
 
 
+async def test_notification_dedup_rollback_on_send_failure(
+    checker: TransactionChecker,
+    mock_db_manager: AsyncMock,
+    mock_notifier: AsyncMock,
+):
+    """When Telegram send fails, the dedup mark is deleted so next cycle retries.
+
+    Without rollback, the DB entry would remain and the notification would be
+    permanently suppressed even though it was never delivered.
+    """
+    checker._spam_detection_enabled = False
+    mock_db_manager.get_recent_transactions.return_value = []
+    mock_db_manager.mark_notification_sent.return_value = True
+    mock_notifier.send_token_notification.side_effect = Exception("Telegram timeout")
+
+    tx = create_mock_tx(
+        BLOCK_ADDR1_START + 1, "0xsender", ADDR1, USDT_CONTRACT, tx_hash="0xfailed_tx"
+    )
+    tx["token_symbol"] = "USDT"
+
+    result = await checker._process_single_transaction(
+        tx, [USER1], ADDR1.lower(), []
+    )
+    # No successful send — count must be 0
+    assert result == 0
+    # The mark must have been set…
+    mock_db_manager.mark_notification_sent.assert_awaited_once_with(USER1, "0xfailed_tx")
+    # …and then rolled back so the next cycle can retry
+    mock_db_manager.delete_notification_sent.assert_awaited_once_with(USER1, "0xfailed_tx")
+
+
 # --- Tests for Contract Age Caching ---
 
 
@@ -1099,20 +1130,33 @@ async def test_db_is_notification_sent(memory_db_manager):
     assert await memory_db_manager.is_notification_sent(1, "0xtxhash") is True
 
 
+async def test_db_delete_notification_sent(memory_db_manager):
+    """delete_notification_sent removes the (user_id, tx_hash) entry so it can be re-inserted."""
+    await memory_db_manager.mark_notification_sent(1, "0xtxhash")
+    assert await memory_db_manager.is_notification_sent(1, "0xtxhash") is True
+
+    await memory_db_manager.delete_notification_sent(1, "0xtxhash")
+    assert await memory_db_manager.is_notification_sent(1, "0xtxhash") is False
+
+    # After deletion a fresh mark succeeds (returns True, not a duplicate)
+    result = await memory_db_manager.mark_notification_sent(1, "0xtxhash")
+    assert result is True
+
+
 async def test_db_cleanup_old_notifications(memory_db_manager):
     """cleanup_old_notifications removes entries older than the cutoff."""
     import sqlite3
 
-    # Insert a record with an old sent_at timestamp directly
+    # Insert a record with an old sent_at timestamp directly (ISO-8601 Z format)
     conn = sqlite3.connect(memory_db_manager.db_path)
     conn.execute(
         "INSERT INTO notification_sent (user_id, tx_hash, sent_at) VALUES (?, ?, ?)",
-        (1, "0xold", "2000-01-01T00:00:00"),
+        (1, "0xold", "2000-01-01T00:00:00Z"),
     )
     conn.commit()
     conn.close()
 
-    # Insert a fresh record via the normal path
+    # Insert a fresh record via the normal path (uses schema default with Z suffix)
     await memory_db_manager.mark_notification_sent(2, "0xrecent")
 
     deleted = await memory_db_manager.cleanup_old_notifications(days=90)
@@ -1120,6 +1164,26 @@ async def test_db_cleanup_old_notifications(memory_db_manager):
     # Recent record must survive
     assert await memory_db_manager.is_notification_sent(2, "0xrecent") is True
     assert await memory_db_manager.is_notification_sent(1, "0xold") is False
+
+
+async def test_db_notification_sent_at_format(memory_db_manager):
+    """sent_at column uses ISO-8601 with Z suffix, not space-separated SQLite datetime."""
+    import sqlite3
+
+    await memory_db_manager.mark_notification_sent(1, "0xhash")
+
+    conn = sqlite3.connect(memory_db_manager.db_path)
+    row = conn.execute(
+        "SELECT sent_at FROM notification_sent WHERE user_id = 1 AND tx_hash = '0xhash'"
+    ).fetchone()
+    conn.close()
+
+    assert row is not None
+    sent_at = row[0]
+    # Must be 'YYYY-MM-DDTHH:MM:SSZ' (T separator, Z suffix) not space-separated
+    assert "T" in sent_at, f"Expected T separator in sent_at, got: {sent_at!r}"
+    assert sent_at.endswith("Z"), f"Expected Z suffix in sent_at, got: {sent_at!r}"
+    assert " " not in sent_at, f"Unexpected space in sent_at, got: {sent_at!r}"
 
 
 # --- Unknown token early return ---

--- a/tests/test_checker.py
+++ b/tests/test_checker.py
@@ -59,7 +59,6 @@ def mock_config():
     config.etherscan_request_delay = 0
     config.max_transaction_age_days = 7
     config.max_transactions_per_check = 10
-    config.notification_dedup_cache_size = 10_000
     config.contract_creation_cache_size = 1_000
 
     token_registry = MagicMock()
@@ -910,14 +909,16 @@ async def test_in_batch_dedup_same_tx_hash_one_notification_per_user(
     assert call_args[1].get("hash") == same_hash
 
 
-async def test_notification_cache_skips_duplicate_send(
+async def test_notification_dedup_skips_duplicate_send(
     checker: TransactionChecker,
     mock_db_manager: AsyncMock,
     mock_notifier: AsyncMock,
 ):
-    """Same (user_id, tx_hash) sent again in same checker instance is skipped (cache hit)."""
+    """Same (user_id, tx_hash) sent again is skipped when mark_notification_sent returns False."""
     checker._spam_detection_enabled = False
     mock_db_manager.get_recent_transactions.return_value = []
+    # First call: newly inserted (True). Second call: already exists (False).
+    mock_db_manager.mark_notification_sent.side_effect = [True, False]
 
     tx = create_mock_tx(
         BLOCK_ADDR1_START + 1, "0xsender", ADDR1, USDT_CONTRACT, tx_hash="0xunique99"
@@ -934,36 +935,30 @@ async def test_notification_cache_skips_duplicate_send(
         tx, [USER1], ADDR1.lower(), []
     )
     assert result2 == 0
-    # Still only one call total (second send skipped by cache)
+    # Still only one call total (second send suppressed by DB dedup)
     mock_notifier.send_token_notification.assert_awaited_once()
 
 
-async def test_notification_cache_disabled_when_size_zero(
-    mock_config: MagicMock,
+async def test_notification_dedup_allows_send_when_new(
+    checker: TransactionChecker,
     mock_db_manager: AsyncMock,
-    mock_etherscan_client: AsyncMock,
     mock_notifier: AsyncMock,
 ):
-    """When notification_dedup_cache_size is 0, cache is disabled; duplicate sends are not suppressed."""
-    mock_config.notification_dedup_cache_size = 0
-    checker = TransactionChecker(mock_config, mock_db_manager, mock_etherscan_client, mock_notifier)
+    """Notification is sent when mark_notification_sent returns True (first time)."""
     checker._spam_detection_enabled = False
     mock_db_manager.get_recent_transactions.return_value = []
+    mock_db_manager.mark_notification_sent.return_value = True
 
     tx = create_mock_tx(
-        BLOCK_ADDR1_START + 1, "0xsender", ADDR1, USDT_CONTRACT, tx_hash="0xdup"
+        BLOCK_ADDR1_START + 1, "0xsender", ADDR1, USDT_CONTRACT, tx_hash="0xnew_tx"
     )
     tx["token_symbol"] = "USDT"
 
-    result1 = await checker._process_single_transaction(
+    result = await checker._process_single_transaction(
         tx, [USER1], ADDR1.lower(), []
     )
-    result2 = await checker._process_single_transaction(
-        tx, [USER1], ADDR1.lower(), []
-    )
-    assert result1 == 1
-    assert result2 == 1
-    assert mock_notifier.send_token_notification.await_count == 2
+    assert result == 1
+    mock_notifier.send_token_notification.assert_awaited_once()
 
 
 # --- Tests for Contract Age Caching ---
@@ -1073,46 +1068,58 @@ def test_contract_creation_cache_disabled_when_size_zero(
     assert len(checker._contract_creation_cache) == 0
 
 
-# --- _add_notification_sent cache eviction ---
+# --- DB notification deduplication ---
 
 
-def test_add_notification_sent_basic(checker: TransactionChecker):
-    """Key is added to cache after first call."""
-    checker._notification_dedup_max_size = 5
-    checker._add_notification_sent(1, "0xtxhash")
-    assert (1, "0xtxhash") in checker._notification_sent_cache
+async def test_db_mark_notification_sent_first_insert(memory_db_manager):
+    """mark_notification_sent returns True on first insert."""
+    result = await memory_db_manager.mark_notification_sent(1, "0xtxhash")
+    assert result is True
 
 
-def test_add_notification_sent_duplicate_no_double_add(checker: TransactionChecker):
-    """Adding same key twice does not grow the deque."""
-    checker._notification_dedup_max_size = 5
-    checker._add_notification_sent(1, "0xtxhash")
-    checker._add_notification_sent(1, "0xtxhash")
-    assert len(checker._notification_sent_order) == 1
+async def test_db_mark_notification_sent_duplicate(memory_db_manager):
+    """mark_notification_sent returns False for a duplicate (user_id, tx_hash)."""
+    await memory_db_manager.mark_notification_sent(1, "0xtxhash")
+    result = await memory_db_manager.mark_notification_sent(1, "0xtxhash")
+    assert result is False
 
 
-def test_add_notification_sent_evicts_oldest_at_capacity(checker: TransactionChecker):
-    """When cache is full, oldest entry is evicted to make room."""
-    checker._notification_dedup_max_size = 3
-    checker._notification_sent_cache.clear()
-    checker._notification_sent_order.clear()
-
-    for i in range(3):
-        checker._add_notification_sent(i, f"0xtx{i}")
-
-    # Cache is now full; adding a 4th should evict (0, "0xtx0")
-    checker._add_notification_sent(99, "0xtxnew")
-
-    assert (0, "0xtx0") not in checker._notification_sent_cache
-    assert (99, "0xtxnew") in checker._notification_sent_cache
-    assert len(checker._notification_sent_cache) == 3
+async def test_db_mark_notification_sent_different_users(memory_db_manager):
+    """Different user_ids for the same tx_hash are independent records."""
+    r1 = await memory_db_manager.mark_notification_sent(1, "0xtxhash")
+    r2 = await memory_db_manager.mark_notification_sent(2, "0xtxhash")
+    assert r1 is True
+    assert r2 is True
 
 
-def test_add_notification_sent_disabled_when_max_size_zero(checker: TransactionChecker):
-    """Cache is a no-op when max_size <= 0."""
-    checker._notification_dedup_max_size = 0
-    checker._add_notification_sent(1, "0xtxhash")
-    assert (1, "0xtxhash") not in checker._notification_sent_cache
+async def test_db_is_notification_sent(memory_db_manager):
+    """is_notification_sent returns False before insert, True after."""
+    assert await memory_db_manager.is_notification_sent(1, "0xtxhash") is False
+    await memory_db_manager.mark_notification_sent(1, "0xtxhash")
+    assert await memory_db_manager.is_notification_sent(1, "0xtxhash") is True
+
+
+async def test_db_cleanup_old_notifications(memory_db_manager):
+    """cleanup_old_notifications removes entries older than the cutoff."""
+    import sqlite3
+
+    # Insert a record with an old sent_at timestamp directly
+    conn = sqlite3.connect(memory_db_manager.db_path)
+    conn.execute(
+        "INSERT INTO notification_sent (user_id, tx_hash, sent_at) VALUES (?, ?, ?)",
+        (1, "0xold", "2000-01-01T00:00:00"),
+    )
+    conn.commit()
+    conn.close()
+
+    # Insert a fresh record via the normal path
+    await memory_db_manager.mark_notification_sent(2, "0xrecent")
+
+    deleted = await memory_db_manager.cleanup_old_notifications(days=90)
+    assert deleted == 1
+    # Recent record must survive
+    assert await memory_db_manager.is_notification_sent(2, "0xrecent") is True
+    assert await memory_db_manager.is_notification_sent(1, "0xold") is False
 
 
 # --- Unknown token early return ---

--- a/usdt_monitor_bot/checker.py
+++ b/usdt_monitor_bot/checker.py
@@ -411,6 +411,8 @@ class TransactionChecker:
         # mark_notification_sent() atomically inserts (user_id, tx_hash) and
         # returns True on first insert, False if already recorded — combining
         # the check-and-set in a single DB roundtrip that survives restarts.
+        # If the Telegram send fails, delete_notification_sent() rolls back the
+        # mark so the next cycle retries rather than permanently suppressing it.
         sent_count = 0
         for user_id in user_ids:
             is_new = await self._db.mark_notification_sent(user_id, tx_hash)
@@ -422,10 +424,12 @@ class TransactionChecker:
                     user_id, tx, tx_token_symbol, address_lower, risk_analysis
                 )
                 sent_count += 1
-            except Exception:
+            except Exception as e:
+                # Roll back the dedup mark so the notification is retried next cycle.
+                await self._db.delete_notification_sent(user_id, tx_hash)
                 logging.warning(
                     f"Notification send failed user={user_id} tx={tx_hash[:16]}...; "
-                    "dedup entry retained — notification will not be retried next cycle",
+                    f"dedup mark rolled back, will retry next cycle: {e}",
                     exc_info=True,
                 )
         return sent_count

--- a/usdt_monitor_bot/checker.py
+++ b/usdt_monitor_bot/checker.py
@@ -7,10 +7,9 @@ and performs spam detection analysis.
 
 # Standard library
 import asyncio
-import contextlib
 import logging
 import time
-from collections import OrderedDict, deque
+from collections import OrderedDict
 from dataclasses import dataclass
 
 # Third-party
@@ -88,10 +87,6 @@ class TransactionChecker:
         # and on overflow we evict the least-recently-used entry.
         self._contract_creation_cache: OrderedDict[str, int | None] = OrderedDict()
         self._contract_creation_cache_max_size = config.contract_creation_cache_size
-        # Bounded in-memory cache of (user_id, tx_hash) to suppress duplicate notifications
-        self._notification_sent_cache: set[tuple[int, str]] = set()
-        self._notification_sent_order: deque[tuple[int, str]] = deque()
-        self._notification_dedup_max_size = config.notification_dedup_cache_size
         self._block_tracker = BlockTracker(etherscan_client)
         logging.debug("TransactionChecker initialized")
 
@@ -336,29 +331,6 @@ class TransactionChecker:
                 exc_info=True,
             )
 
-    def _add_notification_sent(self, user_id: int, tx_hash: str) -> None:
-        """Record (user_id, tx_hash) in the bounded dedup cache and evict oldest if over cap."""
-        if self._notification_dedup_max_size <= 0:
-            return  # Cache disabled when size is not positive
-        key = (user_id, tx_hash)
-        if key in self._notification_sent_cache:
-            return
-        while (
-            len(self._notification_sent_order) >= self._notification_dedup_max_size
-            and self._notification_sent_order
-        ):
-            old = self._notification_sent_order.popleft()
-            self._notification_sent_cache.discard(old)
-        self._notification_sent_cache.add(key)
-        self._notification_sent_order.append(key)
-
-    def _remove_notification_sent(self, user_id: int, tx_hash: str) -> None:
-        """Roll back a dedup cache entry — used when a notification send fails."""
-        key = (user_id, tx_hash)
-        self._notification_sent_cache.discard(key)
-        with contextlib.suppress(ValueError):
-            self._notification_sent_order.remove(key)
-
     async def _process_single_transaction(
         self,
         tx: dict,
@@ -435,22 +407,27 @@ class TransactionChecker:
             logging.debug(f"Suppressing notification for spam tx={tx_hash[:16]}...")
             return 0
 
-        # Send notifications for legitimate transactions only (skip if already sent recently when cache enabled)
-        # Register in dedup cache BEFORE the await to close the window between check and send;
-        # roll back on failure so the next cycle can retry.
+        # Send notifications for legitimate transactions only.
+        # mark_notification_sent() atomically inserts (user_id, tx_hash) and
+        # returns True on first insert, False if already recorded — combining
+        # the check-and-set in a single DB roundtrip that survives restarts.
         sent_count = 0
         for user_id in user_ids:
-            if self._notification_dedup_max_size > 0 and (user_id, tx_hash) in self._notification_sent_cache:
+            is_new = await self._db.mark_notification_sent(user_id, tx_hash)
+            if not is_new:
                 logging.debug(f"Skip duplicate notify user={user_id} tx={tx_hash[:16]}...")
                 continue
-            self._add_notification_sent(user_id, tx_hash)
             try:
                 await self._notifier.send_token_notification(
                     user_id, tx, tx_token_symbol, address_lower, risk_analysis
                 )
                 sent_count += 1
             except Exception:
-                self._remove_notification_sent(user_id, tx_hash)
+                logging.warning(
+                    f"Notification send failed user={user_id} tx={tx_hash[:16]}...; "
+                    "dedup entry retained — notification will not be retried next cycle",
+                    exc_info=True,
+                )
         return sent_count
 
     async def _prefetch_enrichment_context(

--- a/usdt_monitor_bot/config.py
+++ b/usdt_monitor_bot/config.py
@@ -57,7 +57,6 @@ class BotConfig:
         max_transactions_per_check: int = 10,  # Only report last 10 transactions per check
         verbose_logging: bool = False,  # Enable DEBUG level logging
         spam_detection_debug: bool = False,  # Enable detailed spam bypass debugging
-        notification_dedup_cache_size: int = 10_000,  # Max (user_id, tx_hash) to remember to suppress duplicate notifications
         contract_creation_cache_size: int = 1_000,  # Max contract addresses to cache creation blocks for
         spam_detector_config: dict | None = None,  # Overrides for SpamDetector thresholds; None means use SpamDetector defaults
         bot_session_connection_limit: int = 10,  # Max concurrent aiohttp connections to Telegram
@@ -103,9 +102,6 @@ class BotConfig:
         # Logging settings
         self.verbose_logging = verbose_logging
         self.spam_detection_debug = spam_detection_debug
-
-        # Notification deduplication (in-memory cache cap)
-        self.notification_dedup_cache_size = notification_dedup_cache_size
 
         # Contract creation block cache cap
         self.contract_creation_cache_size = contract_creation_cache_size
@@ -238,11 +234,6 @@ def load_config() -> BotConfig:
     verbose_env = os.getenv("VERBOSE", "").lower()
     verbose_logging = verbose_env in ("true", "1", "yes", "on")
 
-    # Notification deduplication cache size (in-memory)
-    notification_dedup_cache_size = _get_env_int(
-        "NOTIFICATION_DEDUP_CACHE_SIZE", 10_000
-    )
-
     # Contract creation block cache size (in-memory)
     contract_creation_cache_size = _get_env_int("CONTRACT_CREATION_CACHE_SIZE", 1_000)
 
@@ -324,7 +315,6 @@ def load_config() -> BotConfig:
         max_transactions_per_check=max_transactions_per_check,
         verbose_logging=verbose_logging,
         spam_detection_debug=spam_detection_debug,
-        notification_dedup_cache_size=notification_dedup_cache_size,
         contract_creation_cache_size=contract_creation_cache_size,
         spam_detector_config=spam_detector_config or None,
         bot_session_connection_limit=bot_session_connection_limit,

--- a/usdt_monitor_bot/database.py
+++ b/usdt_monitor_bot/database.py
@@ -219,6 +219,16 @@ class DatabaseManager:
             # on every checker cycle x monitored address.
             """CREATE INDEX IF NOT EXISTS idx_wallets_address
                    ON wallets(address)""",
+
+            # Persistent notification deduplication: survives restarts and scales
+            # correctly with large user counts. PRIMARY KEY provides atomic
+            # INSERT-or-ignore semantics without a separate SELECT check.
+            """CREATE TABLE IF NOT EXISTS notification_sent (
+                   user_id INTEGER NOT NULL,
+                   tx_hash TEXT NOT NULL,
+                   sent_at TEXT NOT NULL DEFAULT (datetime('now')),
+                   PRIMARY KEY (user_id, tx_hash)
+               ) STRICT""",
         ]
         success = True
         for query in queries:
@@ -647,6 +657,54 @@ class DatabaseManager:
         """
         return await self._run_sync_db_operation(
             self._get_known_senders_sync, monitored_address, sender_addresses
+        )
+
+    # --- Notification Deduplication Operations ---
+    def _mark_notification_sent_sync(self, user_id: int, tx_hash: str) -> bool:
+        """Insert (user_id, tx_hash). Returns True if newly inserted, False if duplicate."""
+        rowcount = self._execute_db_query(
+            "INSERT OR IGNORE INTO notification_sent (user_id, tx_hash) VALUES (?, ?)",
+            (user_id, tx_hash),
+            commit=True,
+        )
+        return rowcount > 0
+
+    def _is_notification_sent_sync(self, user_id: int, tx_hash: str) -> bool:
+        """Return True if this notification was already sent."""
+        result = self._execute_db_query(
+            "SELECT 1 FROM notification_sent WHERE user_id = ? AND tx_hash = ? LIMIT 1",
+            (user_id, tx_hash),
+            fetch_one=True,
+        )
+        return result is not None
+
+    def _cleanup_old_notifications_sync(self, days: int = 90) -> int:
+        """Delete entries older than `days` days. Returns count deleted."""
+        cutoff = datetime.now(UTC) - timedelta(days=days)
+        cutoff_iso = cutoff.isoformat()
+        rowcount = self._execute_db_query(
+            "DELETE FROM notification_sent WHERE sent_at < ?",
+            (cutoff_iso,),
+            commit=True,
+        )
+        return rowcount if rowcount and rowcount > 0 else 0
+
+    async def mark_notification_sent(self, user_id: int, tx_hash: str) -> bool:
+        """Insert (user_id, tx_hash). Returns True if newly inserted, False if duplicate."""
+        return await self._run_sync_db_operation(
+            self._mark_notification_sent_sync, user_id, tx_hash
+        )
+
+    async def is_notification_sent(self, user_id: int, tx_hash: str) -> bool:
+        """Return True if this notification was already sent."""
+        return await self._run_sync_db_operation(
+            self._is_notification_sent_sync, user_id, tx_hash
+        )
+
+    async def cleanup_old_notifications(self, days: int = 90) -> int:
+        """Delete entries older than `days` days. Returns count deleted."""
+        return await self._run_sync_db_operation(
+            self._cleanup_old_notifications_sync, days
         )
 
     # --- Spam Transaction Operations ---

--- a/usdt_monitor_bot/database.py
+++ b/usdt_monitor_bot/database.py
@@ -223,12 +223,18 @@ class DatabaseManager:
             # Persistent notification deduplication: survives restarts and scales
             # correctly with large user counts. PRIMARY KEY provides atomic
             # INSERT-or-ignore semantics without a separate SELECT check.
+            # strftime stores ISO-8601 with Z suffix (e.g. 2024-01-01T12:00:00Z)
+            # so string comparisons in cleanup_old_notifications are correct.
             """CREATE TABLE IF NOT EXISTS notification_sent (
                    user_id INTEGER NOT NULL,
                    tx_hash TEXT NOT NULL,
-                   sent_at TEXT NOT NULL DEFAULT (datetime('now')),
+                   sent_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%SZ', 'now')),
                    PRIMARY KEY (user_id, tx_hash)
                ) STRICT""",
+            # Speeds up cleanup_old_notifications which filters by sent_at.
+            # Without this index the DELETE scans the entire table every cleanup cycle.
+            """CREATE INDEX IF NOT EXISTS idx_notification_sent_at
+                   ON notification_sent(sent_at)""",
         ]
         success = True
         for query in queries:
@@ -669,6 +675,14 @@ class DatabaseManager:
         )
         return rowcount > 0
 
+    def _delete_notification_sent_sync(self, user_id: int, tx_hash: str) -> None:
+        """Delete a (user_id, tx_hash) dedup entry. Used to roll back a mark on send failure."""
+        self._execute_db_query(
+            "DELETE FROM notification_sent WHERE user_id = ? AND tx_hash = ?",
+            (user_id, tx_hash),
+            commit=True,
+        )
+
     def _is_notification_sent_sync(self, user_id: int, tx_hash: str) -> bool:
         """Return True if this notification was already sent."""
         result = self._execute_db_query(
@@ -681,10 +695,15 @@ class DatabaseManager:
     def _cleanup_old_notifications_sync(self, days: int = 90) -> int:
         """Delete entries older than `days` days. Returns count deleted."""
         cutoff = datetime.now(UTC) - timedelta(days=days)
-        cutoff_iso = cutoff.isoformat()
+        # Use the same format as the schema default (strftime '%Y-%m-%dT%H:%M:%SZ')
+        # so string comparisons work correctly. datetime.isoformat() produces
+        # '2024-01-01T12:00:00+00:00' whose '+' sorts AFTER 'Z' (0x2B > 0x5A is
+        # False, but '+00:00' vs 'Z' differs in length and prefix), causing
+        # mismatches. strftime with 'Z' matches stored values exactly.
+        cutoff_str = cutoff.strftime('%Y-%m-%dT%H:%M:%SZ')
         rowcount = self._execute_db_query(
             "DELETE FROM notification_sent WHERE sent_at < ?",
-            (cutoff_iso,),
+            (cutoff_str,),
             commit=True,
         )
         return rowcount if rowcount and rowcount > 0 else 0
@@ -693,6 +712,17 @@ class DatabaseManager:
         """Insert (user_id, tx_hash). Returns True if newly inserted, False if duplicate."""
         return await self._run_sync_db_operation(
             self._mark_notification_sent_sync, user_id, tx_hash
+        )
+
+    async def delete_notification_sent(self, user_id: int, tx_hash: str) -> None:
+        """Delete (user_id, tx_hash) dedup entry.
+
+        Called to roll back a mark when the actual Telegram send fails, so the
+        notification is retried on the next checker cycle instead of being
+        permanently suppressed.
+        """
+        await self._run_sync_db_operation(
+            self._delete_notification_sent_sync, user_id, tx_hash
         )
 
     async def is_notification_sent(self, user_id: int, tx_hash: str) -> bool:


### PR DESCRIPTION
## Summary

Replace the in-memory `(user_id, tx_hash)` notification dedup cache with a persistent `notification_sent` DB table.

**Problem:** The in-memory cache is capped at 10,000 entries (global across all users). At >5k active users it evicts within a cycle, causing duplicate notifications. It also resets on every restart.

**Changes:**
- New `notification_sent (user_id, tx_hash, sent_at)` table with `PRIMARY KEY (user_id, tx_hash)` — deduplication is now a cheap `INSERT OR IGNORE`
- `mark_notification_sent()` returns `True` (first send) or `False` (duplicate) atomically
- Periodic `cleanup_old_notifications(days=90)` prunes old entries
- Removed `_notification_sent_cache` (set), `_notification_sent_order` (deque), and `NOTIFICATION_DEDUP_CACHE_SIZE` env var
- Dedup now survives restarts

## Test plan
- [ ] `ruff check` passes
- [ ] `pytest` passes
- [ ] Manual: restart bot mid-cycle, confirm no duplicate notifications on already-sent txs